### PR TITLE
Tha 0829

### DIFF
--- a/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1695 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified  </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,240 </_Sample size (HH)_>
+<_Sample size (IND)_> 			74,433 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-23] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs281.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = (area == 1)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1690 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified  </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,240 </_Sample size (HH)_>
+<_Sample size (IND)_> 			74,433 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-23] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q1\THA_1985_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q1\THA_1985_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs281.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = (area == 1)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+

--- a/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1694 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified  </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,240 </_Sample size (HH)_>
+<_Sample size (IND)_> 			74,433 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-23] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q1\THA_1985_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q1\THA_1985_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs281.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = (area == 1)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+

--- a/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q1/THA_1985_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -862,6 +862,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1684 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,367 </_Sample size (HH)_>
+<_Sample size (IND)_> 			80,166 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs282.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1679 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,367 </_Sample size (HH)_>
+<_Sample size (IND)_> 			80,166 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q2\THA_1985_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q2\THA_1985_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs282.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+
+

--- a/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1684 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,367 </_Sample size (HH)_>
+<_Sample size (IND)_> 			80,166 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q2\THA_1985_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q2\THA_1985_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs282.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+
+

--- a/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q2/THA_1985_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -858,6 +858,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1703 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,952 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,358 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1985_LFS\THA_1985_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs283.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+**# Bookmark #1
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1695 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,952 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,358 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q3\THA_1985_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q3\THA_1985_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs283.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+**# Bookmark #1
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1699 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,952 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,358 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q3\THA_1985_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1985_LFS-Q3\THA_1985_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs283.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1985
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1985
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+**# Bookmark #1
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1985_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1985_LFS-Q3/THA_1985_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1985_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -866,9 +866,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1693 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q2 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,656 </_Sample size (HH)_>
+<_Sample size (IND)_> 			83,092 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1986_LFS\THA_1986_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1986_LFS\THA_1986_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs292.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1686 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q2 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,656 </_Sample size (HH)_>
+<_Sample size (IND)_> 			83,092 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q2\THA_1986_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q2\THA_1986_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs292.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -865,6 +865,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q2/THA_1986_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1691 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q2 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,656 </_Sample size (HH)_>
+<_Sample size (IND)_> 			83,092 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q2\THA_1986_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q2\THA_1986_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs292.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1698 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q3 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			18,346 </_Sample size (HH)_>
+<_Sample size (IND)_> 			77,237 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1986_LFS\THA_1986_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1986_LFS\THA_1986_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs293.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw== 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 & avaiwk== 1
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus!=3
+	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1693 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q3 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			18,346 </_Sample size (HH)_>
+<_Sample size (IND)_> 			77,237 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q3\THA_1986_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q3\THA_1986_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs293.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw== 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 & avaiwk== 1
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus!=3
+	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -867,9 +867,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1986_LFS-Q3/THA_1986_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1986_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1697 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1986_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1986 Q3 </_Survey Title_>
+<_Survey Year_>					1986 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			18,346 </_Sample size (HH)_>
+<_Sample size (IND)_> 			77,237 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q3\THA_1986_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1986_LFS-Q3\THA_1986_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs293.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1986
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1986
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw== 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 & avaiwk== 1
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus!=3
+	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1986_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1707 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q1 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,066 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,657 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs301.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1702 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q1 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,066 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,657 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q1\THA_1987_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q1\THA_1987_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs301.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1706 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q1 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,066 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,657 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q1\THA_1987_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q1\THA_1987_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs301.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q1/THA_1987_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -873,6 +873,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1693 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q2 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,231 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,181 </_Sample size (IND)_>
+<_Sampling method_> 			No information available </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs302.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1689 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q2 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,231 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,181 </_Sample size (IND)_>
+<_Sampling method_> 			No information available </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q2\THA_1987_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q2\THA_1987_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs302.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+		label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1694 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q2 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,231 </_Sample size (HH)_>
+<_Sample size (IND)_> 			78,181 </_Sample size (IND)_>
+<_Sampling method_> 			No information available </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q2\THA_1987_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q2\THA_1987_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs302.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+		label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q2/THA_1987_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -873,6 +873,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1707 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q3 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,719 </_Sample size (HH)_>
+<_Sample size (IND)_> 			69,698 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1987_LFS\THA_1987_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs303.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1701 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q3 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,719 </_Sample size (HH)_>
+<_Sample size (IND)_> 			69,698 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q3\THA_1987_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q3\THA_1987_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs303.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1706 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1987_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1987 Q3 </_Survey Title_>
+<_Survey Year_>					1987 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,719 </_Sample size (HH)_>
+<_Sample size (IND)_> 			69,698 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q3\THA_1987_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1987_LFS-Q3\THA_1987_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs303.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1987
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1987
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 7
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1987_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1987_LFS-Q3/THA_1987_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1987_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -873,6 +873,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1685 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1988_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1988 Q1 </_Survey Title_>
+<_Survey Year_>					1988 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,046 </_Sample size (HH)_>
+<_Sample size (IND)_> 			73,060 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1988_LFS\THA_1988_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1988_LFS\THA_1988_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs311.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-[##]"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = ""
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "V01"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "1958"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1679 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1988_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1988 Q1 </_Survey Title_>
+<_Survey Year_>					1988 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,046 </_Sample size (HH)_>
+<_Sample size (IND)_> 			73,060 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup, and updated the code for variables identifying ICLS, ISCO and ISIC versions.
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q1\THA_1988_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q1\THA_1988_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs311.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1683 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1988_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1988 Q1 </_Survey Title_>
+<_Survey Year_>					1988 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			17,046 </_Sample size (HH)_>
+<_Sample size (IND)_> 			73,060 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup, and updated the code for variables identifying ICLS, ISCO and ISIC versions.
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q1\THA_1988_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q1\THA_1988_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs311.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q1/THA_1988_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -845,6 +845,7 @@ foreach v of local ed_var {
 	gen industry_orig = indus
 	tostring industry_orig, replace
 	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if lstatus!=1
 	label var industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
@@ -857,6 +858,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1687 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,920 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,727 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1988_LFS\THA_1988_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1988_LFS\THA_1988_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs313.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-[##]"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = ""
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "V01"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "1958"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = (union2 == 1)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1680 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,920 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,727 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup, and updated the code for variables identifying ICLS, ISCO and ISIC versions.
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q3\THA_1988_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q3\THA_1988_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs313.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = (union2 == 1)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -844,6 +844,7 @@ foreach v of local ed_var {
 	gen industry_orig = indus
 	tostring industry_orig, replace
 	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if lstatus!=1
 	label var industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 
@@ -857,6 +858,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1988_LFS-Q3/THA_1988_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1988_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1685 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			16,920 </_Sample size (HH)_>
+<_Sample size (IND)_> 			71,727 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup, and updated the code for variables identifying ICLS, ISCO and ISIC versions.
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q3\THA_1988_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1988_LFS-Q3\THA_1988_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs313.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1988
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1988
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk== 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk== 1) | (lookwk == 1 & avaiwk== 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= .
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= .
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = (union2 == 1)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+Since the variable, hour_oo pertains to hours worked other than the primary job in the past 7 days, there is no way to determine the separate the hours worked for the secondary job from the other jobs as both are lumped together. 
+
+Thus, we set hours worked for secondary job as missing, and instead, code the lumped hours variable as hours worked for other jobs. 
+
+Also, it does not make sense to assume individuals reporting non-missing hour_oo have a secondary job. And, it may be a source of confusion for people seeing that there is a value for hours worked in the secondary job but the empstat2 variable is missing.
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = hour_oo
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1988_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1715 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q1 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,258 </_Sample size (HH)_>
+<_Sample size (IND)_> 			98,910 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs321.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1711 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q1 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,258 </_Sample size (HH)_>
+<_Sample size (IND)_> 			98,910 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q1\THA_1989_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q1\THA_1989_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs321.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -870,6 +870,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q1/THA_1989_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1715 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q1 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,258 </_Sample size (HH)_>
+<_Sample size (IND)_> 			98,910 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q1\THA_1989_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q1\THA_1989_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs321.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1688 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q2 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,976 </_Sample size (HH)_>
+<_Sample size (IND)_> 			102,925 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs322.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1683 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q2 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,976 </_Sample size (HH)_>
+<_Sample size (IND)_> 			102,925 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q2\THA_1989_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q2\THA_1989_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs322.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1687 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q2 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,976 </_Sample size (HH)_>
+<_Sample size (IND)_> 			102,925 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q2\THA_1989_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q2\THA_1989_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs322.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q2/THA_1989_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -866,9 +866,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1718 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q3 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,726 </_Sample size (HH)_>
+<_Sample size (IND)_> 			95,592 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1989_LFS\THA_1989_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs323.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  11 "Mae Hong Son" 12 "Chiang Mai"	13 "Phayso" 14 "Chiang Rai" 15 "Nan" 16 "Lamjphun" 17 "Lampang" 18 "Phrae" 19 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 21 "Loei"	22 "Udon Thani" 23 "Nong Khai" 24 "Sakon Nakhon" 25 "Nakhon Phanom" 26 "Kalasin" 27 "Roi Et" 28 "Maha Sarakham" 29 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  31 "Chumphon" 32 "Ranong" 33 "Surat Thani" 34 "Phangnga" 35 "Phuket" 36 "Krabi" 37 "Nakhon Si Thammarat" 38 "Phatthalung" 39 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 41 "Kanchanaburi" 42 "Suphan Buri" 43 "Ratchaburi" 44 "Prachuap Khiri Khan" 45 "Phetchaburi" 46 "Nakhon Pathom" 47 "Samut Songkhram"	48 "Samut Sakhon" 49 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 51 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1717 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q3 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,726 </_Sample size (HH)_>
+<_Sample size (IND)_> 			95,592 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q3\THA_1989_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q3\THA_1989_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs323.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1721 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1989_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1989 Q3 </_Survey Title_>
+<_Survey Year_>					1989 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,726 </_Sample size (HH)_>
+<_Sample size (IND)_> 			95,592 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Fixed the subnatid2 labels, removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q3\THA_1989_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1989_LFS-Q3\THA_1989_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs323.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1989
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1989
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1989_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1989_LFS-Q3/THA_1989_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1989_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -872,6 +872,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1704 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1990_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1990 Q1 </_Survey Title_>
+<_Survey Year_>					1990 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			22,619 </_Sample size (HH)_>
+<_Sample size (IND)_> 			90,135 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1990_LFS\THA_1990_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1990_LFS\THA_1990_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs333.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1990
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1990
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1990_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1698 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1990_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1990 Q1 </_Survey Title_>
+<_Survey Year_>					1990 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			22,619 </_Sample size (HH)_>
+<_Sample size (IND)_> 			90,135 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1990_LFS-Q3\THA_1990_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1990_LFS-Q3\THA_1990_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs333.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1990
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1990
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1990_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1703 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1990_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1990 Q1 </_Survey Title_>
+<_Survey Year_>					1990 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			22,619 </_Sample size (HH)_>
+<_Sample size (IND)_> 			90,135 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1990_LFS-Q3\THA_1990_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1990_LFS-Q3\THA_1990_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs333.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1990
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1990
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+	drop if x>=1 & wt>9999.9 & !missing(wt)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = .
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 8 10 11 12 13 14 = 5) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1990_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1990_LFS-Q3/THA_1990_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1990_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -862,6 +862,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1735 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q1 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,999 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,006 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs341.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+	
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1726 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q1 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,999 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,006 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q1\THA_1991_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q1\THA_1991_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs341.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+	
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1730 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q1 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,999 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,006 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q1\THA_1991_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q1\THA_1991_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs341.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+	
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q1/THA_1991_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -884,6 +884,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1694 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q2 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,205 </_Sample size (HH)_>
+<_Sample size (IND)_> 			99,127 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs342.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1685 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q2 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,205 </_Sample size (HH)_>
+<_Sample size (IND)_> 			99,127 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q2\THA_1991_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q2\THA_1991_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs342.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1689 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q2 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,205 </_Sample size (HH)_>
+<_Sample size (IND)_> 			99,127 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q2\THA_1991_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q2\THA_1991_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs342.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q2/THA_1991_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -870,6 +870,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1742 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q3 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,293 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,449 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1991_LFS\THA_1991_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs343.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1734 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q3 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,293 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,449 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q3\THA_1991_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q3\THA_1991_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs343.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -890,6 +890,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1991_LFS-Q3/THA_1991_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1991_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1737 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1991_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1991 Q3 </_Survey Title_>
+<_Survey Year_>					1991 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,293 </_Sample size (HH)_>
+<_Sample size (IND)_> 			93,449 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q3\THA_1991_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1991_LFS-Q3\THA_1991_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs343.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1991
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1991
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1991_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1737 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q1 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,714 </_Sample size (HH)_>
+<_Sample size (IND)_> 			92,832 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs351.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1730 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q1 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,714 </_Sample size (HH)_>
+<_Sample size (IND)_> 			92,832 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q1\THA_1992_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q1\THA_1992_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs351.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1735 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q1 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,714 </_Sample size (HH)_>
+<_Sample size (IND)_> 			92,832 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q1\THA_1992_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q1\THA_1992_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs351.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q1/THA_1992_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -886,9 +886,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1693 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,658 </_Sample size (HH)_>
+<_Sample size (IND)_> 			97,366 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs352.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1686 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,658 </_Sample size (HH)_>
+<_Sample size (IND)_> 			97,366 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q2\THA_1992_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q2\THA_1992_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs352.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1691 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q2 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,658 </_Sample size (HH)_>
+<_Sample size (IND)_> 			97,366 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q2\THA_1992_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q2\THA_1992_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs352.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q2/THA_1992_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -867,6 +867,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1738 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,402 </_Sample size (HH)_>
+<_Sample size (IND)_> 			91,015 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1992_LFS\THA_1992_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs353.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>
+
+}

--- a/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1729 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,402 </_Sample size (HH)_>
+<_Sample size (IND)_> 			91,015 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q3\THA_1992_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q3\THA_1992_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs353.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+
+}

--- a/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -882,6 +882,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1992_LFS-Q3/THA_1992_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1992_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1734 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1985_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1985 Q3 </_Survey Title_>
+<_Survey Year_>					1985 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			24,402 </_Sample size (HH)_>
+<_Sample size (IND)_> 			91,015 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q3\THA_1992_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1992_LFS-Q3\THA_1992_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs353.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1992
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1992
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1992_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+
+}

--- a/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1749 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q1 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,736 </_Sample size (HH)_>
+<_Sample size (IND)_> 			87,782 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1993_LFS\THA_1993_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1993_LFS\THA_1993_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs361.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>ic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1742 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q1 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,736 </_Sample size (HH)_>
+<_Sample size (IND)_> 			87,782 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q1\THA_1993_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q1\THA_1993_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs361.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>ic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1747 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q1 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,736 </_Sample size (HH)_>
+<_Sample size (IND)_> 			87,782 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q1\THA_1993_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q1\THA_1993_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs361.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>ic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 11
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q1/THA_1993_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -896,6 +896,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1735 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q3 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			86,039 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1993_LFS\THA_1993_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1993_LFS\THA_1993_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs363.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+**<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1726 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q3 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			86,039 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q3\THA_1993_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q3\THA_1993_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs363.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+**<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1732 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1993_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1993 Q3 </_Survey Title_>
+<_Survey Year_>					1993 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			23,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			86,039 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and changed ISIC code to 2 digits
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q3\THA_1993_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1993_LFS-Q3\THA_1993_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs363.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1993
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1993
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 11 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+**<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1993_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1993_LFS-Q3/THA_1993_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1993_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -885,6 +885,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q1 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			50,655 </_Sample size (HH)_>
+<_Sample size (IND)_> 			184,031 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs371.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q1 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			50,655 </_Sample size (HH)_>
+<_Sample size (IND)_> 			184,031 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q1\THA_1994_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q1\THA_1994_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs371.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -937,9 +937,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q1/THA_1994_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1787 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q1 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			50,655 </_Sample size (HH)_>
+<_Sample size (IND)_> 			184,031 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q1\THA_1994_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q1\THA_1994_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs371.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1725 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q2 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			82,981 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs372.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1737 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q2 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			82,981 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q2\THA_1994_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q2\THA_1994_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs372.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1742 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q2 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			82,981 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q2\THA_1994_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q2\THA_1994_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs372.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	gen migrated_from_cat = .
+
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q2/THA_1994_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -922,6 +922,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q3 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,313 </_Sample size (HH)_>
+<_Sample size (IND)_> 			177,958 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1994_LFS\THA_1994_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs373.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q3 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,313 </_Sample size (HH)_>
+<_Sample size (IND)_> 			177,958 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q3\THA_1994_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q3\THA_1994_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs373.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -931,6 +931,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1994_LFS-Q3/THA_1994_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1994_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1782 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1994_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1994 Q3 </_Survey Title_>
+<_Survey Year_>					1994 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,313 </_Sample size (HH)_>
+<_Sample size (IND)_> 			177,958 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q3\THA_1994_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1994_LFS-Q3\THA_1994_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs373.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1994
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1994
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 11
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1994_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q1 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,288 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,717 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1995_LFS\THA_1995_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1995_LFS\THA_1995_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs381.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q1 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,288 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,717 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q1\THA_1995_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q1\THA_1995_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs381.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -928,9 +928,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q1/THA_1995_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q1 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,288 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,717 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q1\THA_1995_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q1\THA_1995_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs381.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =11
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1757 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q3 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,184 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,267 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1995_LFS\THA_1995_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1995_LFS\THA_1995_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs383.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q3 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,184 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,267 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q3\THA_1995_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q3\THA_1995_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs383.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1995_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1995 Q3 </_Survey Title_>
+<_Survey Year_>					1995 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,184 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,267 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q3\THA_1995_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1995_LFS-Q3\THA_1995_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs383.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1995
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1995
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1995_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1995_LFS-Q3/THA_1995_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1995_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -923,8 +923,8 @@ foreach v of local ed_var {
 Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
 
 </_industrycat_isic_note>*/
-
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q1 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,424 </_Sample size (HH)_>
+<_Sample size (IND)_> 			129,128 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs391.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q1 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,424 </_Sample size (HH)_>
+<_Sample size (IND)_> 			129,128 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q1\THA_1996_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q1\THA_1996_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs391.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1786 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q1 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,424 </_Sample size (HH)_>
+<_Sample size (IND)_> 			129,128 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q1\THA_1996_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q1\THA_1996_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs391.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q1/THA_1996_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -938,7 +938,8 @@ Industry code is based on the 1958 ISIC (version 1)
 
 </_industrycat_isic_note>*/
 
-	gen industrycat_isic = industry_orig
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1720 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q2 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,034 </_Sample size (HH)_>
+<_Sample size (IND)_> 			59,145 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs392.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = . if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1727 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q2 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,034 </_Sample size (HH)_>
+<_Sample size (IND)_> 			59,145 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q2\THA_1996_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q2\THA_1996_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs392.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = . if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1732 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q2 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,034 </_Sample size (HH)_>
+<_Sample size (IND)_> 			59,145 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q2\THA_1996_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q2\THA_1996_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs392.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = . if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u= .
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q2/THA_1996_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -910,8 +910,8 @@ foreach v of local ed_var {
 Industry code is based on the 1958 ISIC (version 1)
 
 </_industrycat_isic_note>*/
-
-	gen industrycat_isic = industry_orig
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q3 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,651 </_Sample size (HH)_>
+<_Sample size (IND)_> 			126,219 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1996_LFS\THA_1996_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs393.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q3 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,651 </_Sample size (HH)_>
+<_Sample size (IND)_> 			126,219 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q3\THA_1996_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q3\THA_1996_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs393.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -924,10 +924,10 @@ Industry code is based on the 1958 ISIC (version 1)
 
 </_industrycat_isic_note>*/
 
-	gen industrycat_isic = industry_orig
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1996_LFS-Q3/THA_1996_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1996_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1996_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1996 Q3 </_Survey Title_>
+<_Survey Year_>					1996 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,651 </_Sample size (HH)_>
+<_Sample size (IND)_> 			126,219 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q3\THA_1996_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1996_LFS-Q3\THA_1996_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs393.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1996
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1996
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwd_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1996_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q1 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,401 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,087 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1997_LFS\THA_1997_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1997_LFS\THA_1997_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs401.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	gen psu = blk_vil_str
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hh_no_str
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == members
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1779 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q1 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,401 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,087 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q1\THA_1997_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q1\THA_1997_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs401.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == members
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -931,7 +931,8 @@ Industry code is based on the 1958 ISIC (version 1)
 
 </_industrycat_isic_note>*/
 
-	gen industrycat_isic = industry_orig
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q1/THA_1997_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q1 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,401 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,087 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q1\THA_1997_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q1\THA_1997_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs401.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == members
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q3 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,612 </_Sample size (HH)_>
+<_Sample size (IND)_> 			175,438 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1997_LFS\THA_1997_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1997_LFS\THA_1997_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs403.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	gen psu = blk_vil_str
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hh_no_str
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "Mae Hong Son" 102 "Chiang Mai"	103 "Phayso" 104 "Chiang Rai" 105 "Nan" 106 "Lamjphun" 107 "Lampang" 108 "Phrae" 109 "Tak" 110 "Sukhothai" 111 "Uttaradit"112 "Kamphaeng Phet" 113 "Phichit" 114 "Uthai Thani" 115 "Nakhon Sawan" 116 "Phitsanulok" 117 "Phetchabun" 201 "Loei"	202 "Udon Thani" 203 "Nong Khai" 204 "Sakon Nakhon" 205 "Nakhon Phanom" 206 "Kalasin" 207 "Roi Et" 208 "Maha Sarakham" 209 "Khon Daen" 210 "Chaiyaphum" 211 "Nakhon Ratchasima" 212 "Buri Ram" 213 "Surin" 214 "Si Sa Ket" 215 "Ubon Ratchathani" 216 "Yasothon" 217 "Mukdahan"  301 "Chumphon" 302 "Ranong" 303 "Surat Thani" 304 "Phangnga" 305 "Phuket" 306 "Krabi" 307 "Nakhon Si Thammarat" 308 "Phatthalung" 309 "Songkhla" 310 "Trang" 311 "Satun" 312 "Pattani" 313 "Yala" 314 "Narathiwat" 401 "Kanchanaburi" 402 "Suphan Buri" 403 "Ratchaburi" 404 "Prachuap Khiri Khan" 405 "Phetchaburi" 406 "Nakhon Pathom" 407 "Samut Songkhram"	408 "Samut Sakhon" 409 "Saraburi" 410 "Lop Buri" 411 "Phranakhon Si Ayutthaya" 412 "Ang Thong" 413 "Sing Buri" 414 "Chai Nat" 415 "Trat" 416 "Chanthaburi" 417 "Rayong" 418 "Chon Buri" 419 "Prachin Buri" 420 "Nakhon Nayok" 421 "Chachoengsao" 422 "Nonthaburi" 423 "Pathum Thani" 424 "Sumut Prakan" 501 "Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == members
+	
+	gen hsize = totfam_size
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta"
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1786 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q3 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,612 </_Sample size (HH)_>
+<_Sample size (IND)_> 			175,438 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q3\THA_1997_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q3\THA_1997_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs403.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == members
+	
+	gen hsize = totfam_size
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1788 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1997_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1997 Q3 </_Survey Title_>
+<_Survey Year_>					1997 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Not specified </_Data collection from_>
+<_Data collection to_>			Not specified </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,612 </_Sample size (HH)_>
+<_Sample size (IND)_> 			175,438 </_Sample size (IND)_>
+<_Sampling method_> 			No information available
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version and subnatid2 labels, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q3\THA_1997_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1997_LFS-Q3\THA_1997_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs403.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 1997
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1997
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "North" 2 "Northeast" 3 "South" 4 "Central" 5 "Bangkok Metropolis"
+
+	label de lblsubnatid1 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-1998, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	egen regprov = concat(reg_str cwt_str)
+	destring regprov, gen(subnatid2)
+
+
+	label de lblsubnatid2  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+</_subnatid1_prev_note> */
+	gen subnatid1_prev = .
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = subnatid2
+	recode subnatid2_prev (476 = 419) (275 = 215) (274 = 202)
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+
+	sdecode subnatid1, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+
+
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	*assert totfam_size == members
+	
+	gen hsize = totfam_size
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	ren marital mrstat
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	replace migrated_years = lenlv if migrated_binary == 1
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping.dta", keep(master match)
+	destring regprov, gen(regprov_num)
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2| status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_> 
+	recode union (2 = 0)
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1997_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1997_LFS-Q3/THA_1997_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1997_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -939,10 +939,10 @@ Industry code is based on the 1958 ISIC (version 1)
 
 </_industrycat_isic_note>*/
 
-	gen industrycat_isic = industry_orig
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q1 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 1998 </_Data collection from_>
+<_Data collection to_>			March 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			170,865 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs411.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1771 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q1 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 1998 </_Data collection from_>
+<_Data collection to_>			March 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			170,865 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q1\THA_1998_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q1\THA_1998_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs411.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1805 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q1 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 1998 </_Data collection from_>
+<_Data collection to_>			March 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			170,865 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q1\THA_1998_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q1\THA_1998_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs411.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q1/THA_1998_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -954,11 +954,10 @@ foreach v of local ed_var {
 Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
 
 </_industrycat_isic_note>*/
-
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1730 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q2 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1998 </_Data collection from_>
+<_Data collection to_>			June 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,186 </_Sample size (HH)_>
+<_Sample size (IND)_> 			79,748 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs412.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1730 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q2 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1998 </_Data collection from_>
+<_Data collection to_>			June 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,186 </_Sample size (HH)_>
+<_Sample size (IND)_> 			79,748 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q2\THA_1998_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q2\THA_1998_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs412.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1739 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q2 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1998 </_Data collection from_>
+<_Data collection to_>			June 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			21,186 </_Sample size (HH)_>
+<_Sample size (IND)_> 			79,748 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q2\THA_1998_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q2\THA_1998_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs412.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q2/THA_1998_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -920,6 +920,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q3 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1998 </_Data collection from_>
+<_Data collection to_>			September 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,768 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,469 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs413.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = wage_type
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1	
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>
+}
+

--- a/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q3 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1998 </_Data collection from_>
+<_Data collection to_>			September 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,768 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,469 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q3\THA_1998_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q3\THA_1998_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs413.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = wage_type
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1	
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+}
+

--- a/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -959,9 +959,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q3/THA_1998_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1808 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q3 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1998 </_Data collection from_>
+<_Data collection to_>			September 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,768 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,469 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q3\THA_1998_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q3\THA_1998_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs413.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+	
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = wage_type
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	ren union union2
+	gen byte union = union2==1	
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>
+}
+

--- a/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1729 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q4 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1998 </_Data collection from_>
+<_Data collection to_>			December 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,077 </_Sample size (HH)_>
+<_Sample size (IND)_> 			182,525 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1998_LFS\THA_1998_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs414.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1730 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q4 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1998 </_Data collection from_>
+<_Data collection to_>			December 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,077 </_Sample size (HH)_>
+<_Sample size (IND)_> 			182,525 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q4\THA_1998_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q4\THA_1998_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs414.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1742 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1998_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1998 Q4 </_Survey Title_>
+<_Survey Year_>					1998 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1998 </_Data collection from_>
+<_Data collection to_>			December 1998 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,077 </_Sample size (HH)_>
+<_Sample size (IND)_> 			182,525 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q4\THA_1998_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1998_LFS-Q4\THA_1998_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs414.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1998
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1998
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = .
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1998_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1998_LFS-Q4/THA_1998_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1998_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -922,9 +922,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q1 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Jan 1999 </_Data collection from_>
+<_Data collection to_>			March 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,123 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,503 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs421.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+	
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1777 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q1 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Jan 1999 </_Data collection from_>
+<_Data collection to_>			March 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,123 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,503 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q1\THA_1999_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q1\THA_1999_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs421.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+	
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -964,9 +964,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q1/THA_1999_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1810 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q1 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		Jan 1999 </_Data collection from_>
+<_Data collection to_>			March 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,123 </_Sample size (HH)_>
+<_Sample size (IND)_> 			167,503 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q1\THA_1999_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q1\THA_1999_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs421.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+	
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+In the data, the minimum age is 7. Not sure if this is an age restriction or just incidental
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q2 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1999 </_Data collection from_>
+<_Data collection to_>			June 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,161 </_Sample size (HH)_>
+<_Sample size (IND)_> 			180,712 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs422.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q2 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1999 </_Data collection from_>
+<_Data collection to_>			June 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,161 </_Sample size (HH)_>
+<_Sample size (IND)_> 			180,712 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q2\THA_1999_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q2\THA_1999_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs422.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1806 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q2 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 1999 </_Data collection from_>
+<_Data collection to_>			June 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,161 </_Sample size (HH)_>
+<_Sample size (IND)_> 			180,712 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q2\THA_1999_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q2\THA_1999_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs422.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q2/THA_1999_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -961,9 +961,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1777 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q3 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1999 </_Data collection from_>
+<_Data collection to_>			September 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,671 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,832 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs423.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q3 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1999 </_Data collection from_>
+<_Data collection to_>			September 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,671 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,832 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q3\THA_1999_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q3\THA_1999_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs423.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -959,6 +959,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q3/THA_1999_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1805 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q3 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 1999 </_Data collection from_>
+<_Data collection to_>			September 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,671 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,832 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q3\THA_1999_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q3\THA_1999_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs423.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q4 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1999 </_Data collection from_>
+<_Data collection to_>			December 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,175 </_Sample size (HH)_>
+<_Sample size (IND)_> 			178,512 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_1999_LFS\THA_1999_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs424.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q4 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1999 </_Data collection from_>
+<_Data collection to_>			December 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,175 </_Sample size (HH)_>
+<_Sample size (IND)_> 			178,512 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q4\THA_1999_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q4\THA_1999_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs424.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -957,6 +957,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_1999_LFS-Q4/THA_1999_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_1999_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1800 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_1999_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 1999 Q4 </_Survey Title_>
+<_Survey Year_>					1999 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 1999 </_Data collection from_>
+<_Data collection to_>			December 1999 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			49,175 </_Sample size (HH)_>
+<_Sample size (IND)_> 			178,512 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q4\THA_1999_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_1999_LFS-Q4\THA_1999_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs424.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 1999
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 1999
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_1999_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1775 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q1 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,636 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs431.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q1 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,636 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q1\THA_2000_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q1\THA_2000_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs431.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1799 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q1 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			164,636 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q1\THA_2000_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q1\THA_2000_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs431.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q1/THA_2000_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -956,6 +956,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1791 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q2 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs432.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2000, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1784 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q2 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q2\THA_2000_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q2\THA_2000_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs432.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2000, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1816 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q2 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q2\THA_2000_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q2\THA_2000_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs432.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2000, the provinces are nested in regions. Approach is to concatenate region and cwd codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q2/THA_2000_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -966,9 +966,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q3 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,562 </_Sample size (HH)_>
+<_Sample size (IND)_> 			161,834 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs433.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnat
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	drop _merge
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q3 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,562 </_Sample size (HH)_>
+<_Sample size (IND)_> 			161,834 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q3\THA_2000_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q3\THA_2000_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs433.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnat
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -951,9 +951,9 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
-
 
 *<_industrycat10_>
 	gen isic_1d = substr(industrycat_isic, 1, 1)

--- a/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q3/THA_2000_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1798 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q3 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			47,562 </_Sample size (HH)_>
+<_Sample size (IND)_> 			161,834 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q3\THA_2000_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q3\THA_2000_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs433.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+
+*</_subnatid2_prev_>
+
+
+*<_subnat
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == hh_mem
+	
+	gen hsize = hh_mem
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age =13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = edcode
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = edcode
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 2 & avaiwk == 2) | (lookwk == 2 & avaiwk ==1) | (lookwk == 1 & avaiwk == 2) | (avaiwk == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & avaiwk == 1) | (lookwk == 1 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q4 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2000_LFS\THA_2000_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs432.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen ISCO58_3d = substr(occup_orig, 1, 3)
+	
+	merge m:1 ISCO58_3d using "$path_in\ISCO58_88_conversion.dta", keep(master match) nogen
+	gen occup_isco = ISCO88_3d_mapped
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q4 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q4\THA_2000_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q4\THA_2000_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs434.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1807 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2000_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2000 Q4 </_Survey Title_>
+<_Survey Year_>					2000 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2000 </_Data collection from_>
+<_Data collection to_>			March 2000 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			48,824 </_Sample size (HH)_>
+<_Sample size (IND)_> 			176,684 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+</_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1958 </_ISCO Version_>
+<_OCCUP National_>			Based on ISCO 1958 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 1 </_ISIC Version_>
+<_INDUS National_>			Based on ISIC version 1 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version, changed ISIC code to 2 digits 
+* Date: [2022-08-03] - Removed code for occup_isco and occup
+* Date: [2022-08-30] - Transform subnatid labels in string
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q4\THA_2000_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2000_LFS-Q4\THA_2000_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs434.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1958"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_1"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2000
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2000
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = .
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area blk_vil hh_no listing {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	
+	replace blk_vil_str = "0" + blk_vil_str if length(blk_vil_str)==2
+	replace blk_vil_str = "00" + blk_vil_str if length(blk_vil_str) == 1
+	
+	replace listing_str =  "0" + listing_str if length(listing_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str area_str blk_vil_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid listing_str)
+	label var pid "Individual ID"
+	
+	isid pid
+	
+	* Then drop duplicates
+	duplicates tag pid, gen(x)
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwt_str area_str blk_vil_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 3 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	label values subnatid2_prev lblsubnatid2_prev
+	
+	gen subnatid2_copy = subnatid2
+	
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = members
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = 13
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = 99
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = mgcode!=1
+	replace migrated_binary = 0 if missing(mgcode) | mgcode == 1
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = prearea  
+	recode migrated_from_urban (2 = 0) (3 = .)
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+	merge m:1 precwd using "$path_in\precwd_mapping_1998.dta", keep(master match) nogen
+	gen regprov_num = subnatid2_copy
+	
+	gen migrated_from_cat = .
+	replace migrated_from_cat = 2 if (pre_regprov == regprov_num) & migrated_binary == 1 & !missing(precwd)
+	
+	replace migrated_from_cat = 3 if (pre_regcode == reg)  & migrated_from_cat!= 2 & migrated_binary == 1 & !missing(precwd)
+		
+	replace migrated_from_cat = 4 if pre_regcode != reg & migrated_binary == 1 & !missing(precwd) & prearea !=3
+	
+	replace migrated_from_cat = 5 if prearea == 3 & migrated_binary == 1 & !missing(precwd)
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = pre_regprov if migrated_binary == 1
+	label de lblmigrated_from_code 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 13
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+
+*<_school_>
+	gen byte school= attend
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (3 = 2) (4 = 3) (5 = 4) (6 = 5) (7 8 = 6) (9 10 11 = 7) (12 13 14 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 | re_ed == 3
+	replace educat_isced = "1" if re_ed == 4
+	replace educat_isced = "2A" if re_ed == 5
+	replace educat_isced = "3A" if re_ed == 6
+	replace educat_isced = "3B" if re_ed == 7
+	replace educat_isced = "3B" if re_ed == 8
+	replace educat_isced = "5A" if re_ed == 9
+	replace educat_isced = "5B" if re_ed == 10
+	replace educat_isced = "5A" if re_ed == 11
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 13 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | perjob == 1 
+	replace lstatus = 2 if (lookwk == 1 & available == 1)
+	replace lstatus = 3 if (lookwk == 2 & available == 2) | (lookwk == 2 & available ==1) | (lookwk == 1 & available == 2) | (available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 2 & available == 1) | (lookwk == 1 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_hr == 1
+	replace underemployment = 0 if lstatus == 1 & more_hr == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+
+	gen byte unempldur_l = floor(dr_seek)/30
+	replace unempldur_l = 12 if unempldur_l >= 12
+	replace unempldur_l = . if lstatus!=2 
+
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+.
+*<_unempldur_u_>
+	gen byte unempldur_u = ceil(dr_seek)/30
+	replace unempldur_u = . if unempldur_u >= 12
+	replace unempldur_u = . if lstatus!=2 
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 1 | status == 2 | status == 6
+	replace empstat = 2 if status == 5
+	replace empstat = 3 if status == 3
+	replace empstat = 4 if status == 4
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and the THA industry codes for 1985 - 2000 are not exact match. The ISIC rev 1 are only up to 3 digits while the THA industry codes are up to 4 digits. The THA documentation for industry codes mentioned that a separate classification system is used to fit the specific country context, and we are not certain about the extent to which the national industry codes differ from the ISIC rev 1 at the 3-digit level. We are able to confirm that the national industry and ISIC rev 1 codes perfectly match at the 2-digit level. Thus, we code industrycat_isic using the first 2 digits of the national industry code.
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = substr(industry_orig, 1, 2)
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occ4 + occ3 + occ2 + occ1
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+*<_occup_isco_>
+
+	gen occup_isco = .
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_skill = .
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen occup = .
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2000_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2000_LFS-Q4/THA_2000_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2000_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -961,6 +961,7 @@ Industry code is based on the 1958 ISIC (version 1). Note that ISIC rev 1 and th
 </_industrycat_isic_note>*/
 
 	gen industrycat_isic = substr(industry_orig, 1, 2)
+	replace industrycat_isic = industrycat_isic + "00"
 	label var industrycat_isic "ISIC code of primary job 7 day recall"
 *</_industrycat_isic_>
 

--- a/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q1 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,038 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,852 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs441.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q1 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,038 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,852 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q1\THA_2001_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q1\THA_2001_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs441.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q1/THA_2001_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q1 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,038 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,852 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q1\THA_2001_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q1\THA_2001_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs441.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+	gen subnatid1_prev = subnatid1
+
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6)  (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q2 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,822 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,814 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs442.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q2 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,822 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,814 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q2\THA_2001_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q2\THA_2001_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs442.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q2/THA_2001_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q2 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,822 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,814 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q2\THA_2001_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q2\THA_2001_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs442.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q3 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,584 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,899 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs443.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q3 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,584 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,899 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q3\THA_2001_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q3\THA_2001_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs443.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q3/THA_2001_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q3 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,584 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,899 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q3\THA_2001_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q3\THA_2001_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs443.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6)  (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q4 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,083 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,991 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2001_LFS\THA_2001_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs444.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q4 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,083 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,991 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q4\THA_2001_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q4\THA_2001_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs444.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2001_LFS-Q4/THA_2001_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2001_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1771 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2001_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2001 Q4 </_Survey Title_>
+<_Survey Year_>					2001 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2001 </_Data collection from_>
+<_Data collection to_>			March 2001 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,083 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,991 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q4\THA_2001_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2001_LFS-Q4\THA_2001_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs444.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2001
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2001
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6)  (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk== 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk== 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if (hour_po>84 & !missing(hour_po)) | hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2001_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1790 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q1 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2002 </_Data collection from_>
+<_Data collection to_>			March 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,598 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,049 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs451.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q1 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2002 </_Data collection from_>
+<_Data collection to_>			March 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,598 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,049 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q1\THA_2002_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q1\THA_2002_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs451.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q1/THA_2002_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1787 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q1 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2002 </_Data collection from_>
+<_Data collection to_>			March 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,598 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,049 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q1\THA_2002_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q1\THA_2002_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs451.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = .
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1784 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q2 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2002 </_Data collection from_>
+<_Data collection to_>			June 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,342 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,175 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs452.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1775 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q2 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2002 </_Data collection from_>
+<_Data collection to_>			June 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,342 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,175 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q2\THA_2002_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q2\THA_2002_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs452.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q2/THA_2002_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1784 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q2 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2002 </_Data collection from_>
+<_Data collection to_>			June 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,342 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,175 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q2\THA_2002_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q2\THA_2002_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs452.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1792 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q3 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2002 </_Data collection from_>
+<_Data collection to_>			September 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,448 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,264 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs453.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - hour_po
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q3 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2002 </_Data collection from_>
+<_Data collection to_>			September 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,448 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,264 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q3\THA_2002_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q3\THA_2002_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs453.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - hour_po
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q3/THA_2002_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1790 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q3 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2002 </_Data collection from_>
+<_Data collection to_>			September 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,448 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,264 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q3\THA_2002_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q3\THA_2002_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs453.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - hour_po
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1790 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q4 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2002 </_Data collection from_>
+<_Data collection to_>			December 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,947 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,250 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2002_LFS\THA_2002_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs454.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q4 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2002 </_Data collection from_>
+<_Data collection to_>			December 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,947 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,250 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q4\THA_2002_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q4\THA_2002_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs454.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2002_LFS-Q4/THA_2002_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2002_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1789 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2002_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2002 Q4 </_Survey Title_>
+<_Survey Year_>					2002 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2002 </_Data collection from_>
+<_Data collection to_>			December 2002 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,947 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,250 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q4\THA_2002_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2002_LFS-Q4\THA_2002_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs454.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2002
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2002
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2002_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1784 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2003 </_Data collection from_>
+<_Data collection to_>			March 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,923 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,993 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs461.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2003 </_Data collection from_>
+<_Data collection to_>			March 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,923 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,993 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q1\THA_2003_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q1\THA_2003_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs461.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q1/THA_2003_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1782 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2003 </_Data collection from_>
+<_Data collection to_>			March 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,923 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,993 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q1\THA_2003_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q1\THA_2003_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs461.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1779 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2003 </_Data collection from_>
+<_Data collection to_>			June 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,131 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,320 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs462.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2003 </_Data collection from_>
+<_Data collection to_>			June 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,131 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,320 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q2\THA_2003_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q2\THA_2003_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs462.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q2/THA_2003_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2003 </_Data collection from_>
+<_Data collection to_>			June 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,131 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,320 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q2\THA_2003_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q2\THA_2003_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs462.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2003 </_Data collection from_>
+<_Data collection to_>			September 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,283 </_Sample size (HH)_>
+<_Sample size (IND)_> 			206,371 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs463.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2003 </_Data collection from_>
+<_Data collection to_>			September 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,283 </_Sample size (HH)_>
+<_Sample size (IND)_> 			206,371 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q3\THA_2003_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q3\THA_2003_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs463.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q3/THA_2003_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2003 </_Data collection from_>
+<_Data collection to_>			September 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,283 </_Sample size (HH)_>
+<_Sample size (IND)_> 			206,371 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q3\THA_2003_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q3\THA_2003_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs463.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1779 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2003 </_Data collection from_>
+<_Data collection to_>			December 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,006 </_Sample size (HH)_>
+<_Sample size (IND)_> 			211,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2003_LFS\THA_2003_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs464.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2003 </_Data collection from_>
+<_Data collection to_>			December 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,006 </_Sample size (HH)_>
+<_Sample size (IND)_> 			211,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q4\THA_2003_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q4\THA_2003_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs464.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2003_LFS-Q4/THA_2003_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2003_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1777 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2003_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2003 Q1 </_Survey Title_>
+<_Survey Year_>					2003 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2003 </_Data collection from_>
+<_Data collection to_>			December 2003 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,006 </_Sample size (HH)_>
+<_Sample size (IND)_> 			211,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q4\THA_2003_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2003_LFS-Q4\THA_2003_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs464.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2003
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2003
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	Based on the 2006 LFS guide, the primary and secondary sampling units were blocks for municipal areas / 	villages for non - municipal areas and private households / persons in the special households respectively. As there is no documentation on the surveys prior to 2006, we based the PSU on this information and we note as a caveat the possibility that the primary sampling unit may be based on a different set of information.
+
+
+	Source: http://www.nso.go.th/sites/2014en/Survey/social/labour/LaborForce/2006/q1/6.%20Full%20Report.pdf
+	
+	</_psu_note> */
+	capture confirm variable blk_vil_str
+			if !_rc {
+			gen blkv_str = blk_vil_str
+		
+	}
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2003_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q1 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2004 </_Data collection from_>
+<_Data collection to_>			March 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,960 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,922 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs471.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q1 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2004 </_Data collection from_>
+<_Data collection to_>			March 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,960 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,922 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q1\THA_2004_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q1\THA_2004_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs471.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q1 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2004 </_Data collection from_>
+<_Data collection to_>			March 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,960 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,922 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q1\THA_2004_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q1\THA_2004_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs471.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q1/THA_2004_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1757,6 +1757,6 @@ foreach var of local kept_vars {
 
 *<_% SAVE_>
 
-save "$path_output\THA_2004_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+save "$path_output\THA_2004_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
 
 *</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q2 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2004 </_Data collection from_>
+<_Data collection to_>			June 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,383 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,042 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs472.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1753 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q2 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2004 </_Data collection from_>
+<_Data collection to_>			June 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,383 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,042 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q2\THA_2004_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q2\THA_2004_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs472.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>	
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q2/THA_2004_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q2 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2004 </_Data collection from_>
+<_Data collection to_>			June 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,383 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,042 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q2\THA_2004_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q2\THA_2004_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs472.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>	
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q3 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2004 </_Data collection from_>
+<_Data collection to_>			September 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,179 </_Sample size (HH)_>
+<_Sample size (IND)_> 			203810 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households a,nd persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs473.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1755 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q3 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2004 </_Data collection from_>
+<_Data collection to_>			September 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,179 </_Sample size (HH)_>
+<_Sample size (IND)_> 			203,810 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households a,nd persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q3\THA_2004_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q3\THA_2004_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs473.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q3/THA_2004_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q3 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2004 </_Data collection from_>
+<_Data collection to_>			September 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			61,179 </_Sample size (HH)_>
+<_Sample size (IND)_> 			203,810 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households a,nd persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q3\THA_2004_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q3\THA_2004_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs473.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q4 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2004 </_Data collection from_>
+<_Data collection to_>			December 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,645 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,103 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2004_LFS\THA_2004_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs474.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1750 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q4 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2004 </_Data collection from_>
+<_Data collection to_>			December 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,645 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,103 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q4\THA_2004_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q4\THA_2004_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs474.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2004_LFS-Q4/THA_2004_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2004_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2004_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2004 Q4 </_Survey Title_>
+<_Survey Year_>					2004 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2004 </_Data collection from_>
+<_Data collection to_>			December 2004 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,645 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,103 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q4\THA_2004_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2004_LFS-Q4\THA_2004_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs474.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2004
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2004
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if re_ed == 1
+	replace educat_isced = "100" if re_ed == 2
+	replace educat_isced = "244" if re_ed == 3
+	replace educat_isced = "344" if inrange(re_ed, 5, 7)
+	replace educat_isced = "354" if re_ed == 8
+	replace educat_isced = "550" if re_ed == 9
+	replace educat_isced = "540" if re_ed == 10
+	replace educat_isced = "660" if inrange(re_ed, 11, 13)
+	replace educat_isced = "" if inrange(re_ed, 14, 15) | re_ed == 4
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2004_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q1 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2005 </_Data collection from_>
+<_Data collection to_>			March 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,361 </_Sample size (HH)_>
+<_Sample size (IND)_> 			212,006 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs481.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1756 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q1 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2005 </_Data collection from_>
+<_Data collection to_>			March 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,361 </_Sample size (HH)_>
+<_Sample size (IND)_> 			212,006 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q1\THA_2005_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q1\THA_2005_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs481.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q1/THA_2005_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q1 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2005 </_Data collection from_>
+<_Data collection to_>			March 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,361 </_Sample size (HH)_>
+<_Sample size (IND)_> 			212,006 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q1\THA_2005_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q1\THA_2005_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs481.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q2 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2005 </_Data collection from_>
+<_Data collection to_>			June 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,061 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,533 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs482.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ * Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q2 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2005 </_Data collection from_>
+<_Data collection to_>			June 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,061 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,533 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q2\THA_2005_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q2\THA_2005_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs482.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ * Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q2/THA_2005_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q2 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2005 </_Data collection from_>
+<_Data collection to_>			June 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,061 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,533 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q2\THA_2005_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q2\THA_2005_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs482.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ * Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q3 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2005 </_Data collection from_>
+<_Data collection to_>			September 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,890 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,952 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs483.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1759 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q3 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2005 </_Data collection from_>
+<_Data collection to_>			September 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,890 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,952 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q3\THA_2005_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q3\THA_2005_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs483.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q3/THA_2005_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q3 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2005 </_Data collection from_>
+<_Data collection to_>			September 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,890 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,952 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q3\THA_2005_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q3\THA_2005_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs483.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q4 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2005 </_Data collection from_>
+<_Data collection to_>			December 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,792 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,835 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2005_LFS\THA_2005_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs484.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	/*<_psu_note_>
+	
+	The primary and secondary sampling units were blocks for municipal areas / 		villages for non - municipal areas and private households / persons in the special households respectively.
+
+	Source: http://catalog.ihsn.org/catalog/4931
+	
+	</_psu_note> */
+	
+	gen psu = psu_no_str
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hh_no_str
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1757 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q4 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2005 </_Data collection from_>
+<_Data collection to_>			December 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,792 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,835 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q4\THA_2005_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q4\THA_2005_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs484.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2005_LFS-Q4/THA_2005_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2005_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2005_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2005 Q4 </_Survey Title_>
+<_Survey Year_>					2005 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2005 </_Data collection from_>
+<_Data collection to_>			December 2005 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			62,792 </_Sample size (HH)_>
+<_Sample size (IND)_> 			208,835 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q4\THA_2005_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2005_LFS-Q4\THA_2005_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs484.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2005
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2005
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2005_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q1 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2006 </_Data collection from_>
+<_Data collection to_>			March 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,839 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,929 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs491.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1756 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q1 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2006 </_Data collection from_>
+<_Data collection to_>			March 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,839 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,929 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q1\THA_2006_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q1\THA_2006_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs491.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q1/THA_2006_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q1 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2006 </_Data collection from_>
+<_Data collection to_>			March 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			63,839 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,929 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q1\THA_2006_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q1\THA_2006_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs491.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- blkv (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace blkv_str = "00" + blkv_str if length(blkv_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str blkv_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwd
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= study
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 4 & age >= 60
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 6 | reunwk == 7 | (reunwk== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	replace whours = . if lstatus!=1
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q2 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2006 </_Data collection from_>
+<_Data collection to_>			June 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			65,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			216,016 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs492.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q2 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2006 </_Data collection from_>
+<_Data collection to_>			June 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			65,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			216,016 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q2\THA_2006_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q2\THA_2006_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs492.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q2/THA_2006_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q2 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2006 </_Data collection from_>
+<_Data collection to_>			June 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			65,911 </_Sample size (HH)_>
+<_Sample size (IND)_> 			216,016 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q2\THA_2006_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q2\THA_2006_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs492.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q3 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2006 </_Data collection from_>
+<_Data collection to_>			September 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,172 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,224 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs493.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1758 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q3 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2006 </_Data collection from_>
+<_Data collection to_>			September 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,172 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,224 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q3\THA_2006_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q3\THA_2006_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs493.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q3/THA_2006_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q3 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2006 </_Data collection from_>
+<_Data collection to_>			September 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,172 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,224 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q3\THA_2006_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q3\THA_2006_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs493.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+**# 
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q4 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2006 </_Data collection from_>
+<_Data collection to_>			December 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,157 </_Sample size (HH)_>
+<_Sample size (IND)_> 			230,030 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectivel`y.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2006_LFS\THA_2006_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs494.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1755 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q4 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2006 </_Data collection from_>
+<_Data collection to_>			December 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,157 </_Sample size (HH)_>
+<_Sample size (IND)_> 			230,030 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q4\THA_2006_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q4\THA_2006_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs494.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2006_LFS-Q4/THA_2006_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2006_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2006_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2006 Q4 </_Survey Title_>
+<_Survey Year_>					2006 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2006 </_Data collection from_>
+<_Data collection to_>			December 2006 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,157 </_Sample size (HH)_>
+<_Sample size (IND)_> 			230,030 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+<_Geographic coverage_> 
+		
+Data is significant at the national level
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q4\THA_2006_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2006_LFS-Q4\THA_2006_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs494.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2006
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2006
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= attend
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 = 7)  (14 15 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 13)
+
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2006_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q1 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2007 </_Data collection from_>
+<_Data collection to_>			March 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,762 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,409 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs501.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1753 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q1 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2007 </_Data collection from_>
+<_Data collection to_>			March 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,762 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,409 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q1\THA_2007_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q1\THA_2007_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs501.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q1/THA_2007_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q1 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2007 </_Data collection from_>
+<_Data collection to_>			March 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,762 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,409 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q1\THA_2007_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q1\THA_2007_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs501.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q2 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2007 </_Data collection from_>
+<_Data collection to_>			June 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,041 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221531 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs502.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1757 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q2 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2007 </_Data collection from_>
+<_Data collection to_>			June 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,041 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221531 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q2\THA_2007_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q2\THA_2007_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs502.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q2/THA_2007_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q2 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2007 </_Data collection from_>
+<_Data collection to_>			June 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,041 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221531 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q2\THA_2007_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q2\THA_2007_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs502.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q3 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2007 </_Data collection from_>
+<_Data collection to_>			September 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,072 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,538 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs503.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1756 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q3 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2007 </_Data collection from_>
+<_Data collection to_>			September 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,072 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,538 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q3\THA_2007_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q3\THA_2007_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs503.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q3/THA_2007_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q3 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2007 </_Data collection from_>
+<_Data collection to_>			September 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,072 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,538 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q3\THA_2007_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q3\THA_2007_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs503.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if  main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q4 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2007 </_Data collection from_>
+<_Data collection to_>			December 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,897 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2007_LFS\THA_2007_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs504.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1757 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q4 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2007 </_Data collection from_>
+<_Data collection to_>			December 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,897 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q4\THA_2007_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q4\THA_2007_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs504.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2007_LFS-Q4/THA_2007_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2007_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2007_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2007 Q4 </_Survey Title_>
+<_Survey Year_>					2007 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2007 </_Data collection from_>
+<_Data collection to_>			December 2007 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,897 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q4\THA_2007_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2007_LFS-Q4\THA_2007_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs504.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "Not stated"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2007
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2007
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2007_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2008 </_Data collection from_>
+<_Data collection to_>			March 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,089 </_Sample size (HH)_>
+<_Sample size (IND)_> 			224,859 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs511.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1756 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2008 </_Data collection from_>
+<_Data collection to_>			March 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,089 </_Sample size (HH)_>
+<_Sample size (IND)_> 			224,859 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q1\THA_2008_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q1\THA_2008_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs511.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q1/THA_2008_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2008 </_Data collection from_>
+<_Data collection to_>			March 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,089 </_Sample size (HH)_>
+<_Sample size (IND)_> 			224,859 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q1\THA_2008_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q1\THA_2008_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs511.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2008 </_Data collection from_>
+<_Data collection to_>			June 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,783 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,613 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs512.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1757 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2008 </_Data collection from_>
+<_Data collection to_>			June 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,783 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,613 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q2\THA_2008_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q2\THA_2008_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs512.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q2/THA_2008_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2008 </_Data collection from_>
+<_Data collection to_>			June 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,783 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,613 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q2\THA_2008_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q2\THA_2008_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs512.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2008 </_Data collection from_>
+<_Data collection to_>			September 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,058 </_Sample size (HH)_>
+<_Sample size (IND)_> 			225,406 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs513.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+	
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2008 </_Data collection from_>
+<_Data collection to_>			September 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,058 </_Sample size (HH)_>
+<_Sample size (IND)_> 			225,406 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q3\THA_2008_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q3\THA_2008_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs513.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+	
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q3/THA_2008_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2008 </_Data collection from_>
+<_Data collection to_>			September 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,058 </_Sample size (HH)_>
+<_Sample size (IND)_> 			225,406 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q3\THA_2008_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q3\THA_2008_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs513.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+	
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2008 </_Data collection from_>
+<_Data collection to_>			December 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,905 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2008_LFS\THA_2008_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs514.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1751 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2008 </_Data collection from_>
+<_Data collection to_>			December 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,905 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q4\THA_2008_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q4\THA_2008_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs514.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2008_LFS-Q4/THA_2008_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2008_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2008_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2008 Q1 </_Survey Title_>
+<_Survey Year_>					2008 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2008 </_Data collection from_>
+<_Data collection to_>			December 2008 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			70,436 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,905 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q4\THA_2008_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2008_LFS-Q4\THA_2008_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs514.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2008
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2008
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area psu_no tmb hh_no line_no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwd_str = "0" + cwd_str if length(cwd_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwd_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwd_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwd
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = rela
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = mrstat
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  baht
+	replace baht = . if baht == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if hour_po == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2008_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2009 </_Data collection from_>
+<_Data collection to_>			March 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs521.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2009 </_Data collection from_>
+<_Data collection to_>			March 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q1\THA_2009_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q1\THA_2009_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs521.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q1/THA_2009_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1763 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2009 </_Data collection from_>
+<_Data collection to_>			March 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q1\THA_2009_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q1\THA_2009_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs521.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2009 </_Data collection from_>
+<_Data collection to_>			June 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs522.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1758 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2009 </_Data collection from_>
+<_Data collection to_>			June 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q2\THA_2009_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q2\THA_2009_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs522.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q2/THA_2009_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2009 </_Data collection from_>
+<_Data collection to_>			June 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q2\THA_2009_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q2\THA_2009_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs522.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2009 </_Data collection from_>
+<_Data collection to_>			September 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs523.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1759 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2009 </_Data collection from_>
+<_Data collection to_>			September 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q3\THA_2009_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q3\THA_2009_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs523.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q3/THA_2009_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2009 </_Data collection from_>
+<_Data collection to_>			September 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q3\THA_2009_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q3\THA_2009_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs523.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2009 </_Data collection from_>
+<_Data collection to_>			December 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2009_LFS\THA_2009_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs524.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2009 </_Data collection from_>
+<_Data collection to_>			December 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q4\THA_2009_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q4\THA_2009_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs524.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2009_LFS-Q4/THA_2009_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2009_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2009_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2009 Q1 </_Survey Title_>
+<_Survey Year_>					2009 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2009 </_Data collection from_>
+<_Data collection to_>			December 2009 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q4\THA_2009_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2009_LFS-Q4\THA_2009_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs524.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2009
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2009
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	gen subnatid2_prev = .
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 0 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+	gen t_hours_others = . 
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2009_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1789 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q1 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2010 </_Data collection from_>
+<_Data collection to_>			March 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,604 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,592 </_Sample size (IND)_>
+<_Sampling method_> 			 
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs531.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if (main_hr>84 & !missing(main_hr)) | main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q1 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2010 </_Data collection from_>
+<_Data collection to_>			March 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,604 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,592 </_Sample size (IND)_>
+<_Sampling method_> 			 
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q1\THA_2010_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q1\THA_2010_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs531.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if (main_hr>84 & !missing(main_hr)) | main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q1/THA_2010_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1795 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q1 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2010 </_Data collection from_>
+<_Data collection to_>			March 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,604 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,592 </_Sample size (IND)_>
+<_Sampling method_> 			 
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q1\THA_2010_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q1\THA_2010_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs531.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if (main_hr>84 & !missing(main_hr)) | main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q2 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2010 </_Data collection from_>
+<_Data collection to_>			June 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,716 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,341 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs532.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q2 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2010 </_Data collection from_>
+<_Data collection to_>			June 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,716 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,341 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q2\THA_2010_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q2\THA_2010_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs532.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q2/THA_2010_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q2 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2010 </_Data collection from_>
+<_Data collection to_>			June 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,716 </_Sample size (HH)_>
+<_Sample size (IND)_> 			223,341 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q2\THA_2010_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q2\THA_2010_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs532.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1775 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q3 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2010 </_Data collection from_>
+<_Data collection to_>			September 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			46,690 </_Sample size (HH)_>
+<_Sample size (IND)_> 			147,718 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs533.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q3 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2010 </_Data collection from_>
+<_Data collection to_>			September 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			46,690 </_Sample size (HH)_>
+<_Sample size (IND)_> 			147,718 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q3\THA_2010_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q3\THA_2010_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs533.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q3/THA_2010_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q3 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2010 </_Data collection from_>
+<_Data collection to_>			September 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			46,690 </_Sample size (HH)_>
+<_Sample size (IND)_> 			147,718 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q3\THA_2010_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q3\THA_2010_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs533.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+	gen subnatid2 = cwt
+
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1780 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q4 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2010 </_Data collection from_>
+<_Data collection to_>			December 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221,167 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2010_LFS\THA_2010_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs534.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+/* <_industrycat_isic_note>
+
+Industry code is based on the 1958 ISIC (version 1)
+
+</_industrycat_isic_note>*/
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+
+/* <_occup_isco_note>
+
+Occupation code is based on the ISCO 1958 
+
+</_occup_isco_note>*/	
+
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q4 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2010 </_Data collection from_>
+<_Data collection to_>			December 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221,167 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q4\THA_2010_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q4\THA_2010_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs534.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) 
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if isic_1d == 5
+	replace industrycat10 = 5 if isic_1d == 4
+	replace industrycat10 = 6 if isic_1d == 6
+	replace industrycat10 = 7 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	replace industrycat10 = 8 if isic_2d == 83
+	replace industrycat10 = 9 if isic_2d == 81
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2010_LFS-Q4/THA_2010_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2010_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1779 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2010_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2010 Q4 </_Survey Title_>
+<_Survey Year_>					2010 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2010 </_Data collection from_>
+<_Data collection to_>			December 2010 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			69,523 </_Sample size (HH)_>
+<_Sample size (IND)_> 			221,167 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the  provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_> 
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 1988 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 1988 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				ISIC version 3 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion, ensure that code 0 is set to missing for relationharm, update ICLS
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q4\THA_2010_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2010_LFS-Q4\THA_2010_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs534.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+* First: drop the duplicates
+duplicates drop
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+*<_isco_version_>
+	gen isco_version = "isco_1988"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2010
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2010
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+
+*<_hhid_>
+/* <_hhid_note>
+
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwt (Province)
+	- area (Municipal/sanitary/nonmunicipal)
+	- tmb (tambon or sub-district)
+	- psu_no (Block village)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no tmb hh_no no {
+	    tostring `var', gen(`var'_str)
+	
+	}
+	
+	* Make sure elements are consistent in length
+	replace cwt_str = "0" + cwt_str if length(cwt_str) == 1
+	replace tmb_str = "0" + tmb_str if length(tmb_str) == 1
+
+	
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace psu_no_str = "00" + psu_no_str if length(psu_no_str) == 1
+	
+	replace no_str =  "0" + no_str if length(no_str)==1
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+
+	egen hhid = concat(reg_str cwt_str tmb_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+	
+*</_hhid_>
+
+
+*<_pid_>
+	
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+	
+	isid pid
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	ren weight weight2
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str tmb_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+
+	/*<_urban_note_>
+	
+	The data does not classify by urban/rural. Instead, classifications were made by municipal/non-municipal/sanitary. Whether these can be mapped to urban/rural have yet to be determined. TO be safe, leave this variable missing
+	
+	</_urban_note> */
+	gen byte urban = area
+	recode urban (2 = 0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1_note>
+
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas"
+	
+	</_subnatid1_note>
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define lblsubnatid1 1 "1 - Bangkok Metropolis" 2 "2 - Central" 3 "3 - North"  4 "4 - Northeast"  5 "5 - South"
+
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+
+/* <_subnatid2_note>
+
+	For surveys held pre-2010, the provinces are nested in regions. Approach is to concatenate region and cwt codes for unique province identifier.
+	
+	</_subnatid2_note> */
+	
+	gen subnatid2 = cwt
+
+label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+*<_subnatidsurvey_>
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+
+* convert codes to string
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen hsize = _N
+
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	ren age age2
+	gen age = age2
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	
+	sort hhid sex neg_age listing
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop tot_head head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert tot_head ==  1
+	
+	gen relationharm = relation
+	recode relationharm (3 4 = 3) (7 = 4) (5 6 8= 5) (9 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1= 2) (5 = 4) (3 = 5) (6=.)
+	* Code 6 = been married but do not know the status (left missing since <~0.1% of obs anyway)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .  
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+*<_migrated_from_cat_>
+
+	
+	gen migrated_from_cat = .
+
+	
+	* Note: there are a few cases of individuals who reported that they do not know where they migrated from
+
+		
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	gen byte school= .
+	replace school = . 
+	recode school (2=0)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+
+* There is no literacy variable in the dataset
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15= 7)  (16 17 = .)
+ 	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = re_ed
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15 
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if seeking == 1 | (seeking == 2 & available == 1)
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available ==1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 4 & age >= 60
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 6 | re_unavail == 7 | (re_unavail== 4 & age<60 & !missing(age))
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 2
+	replace ocusec = 2 if status == 1 | status == 3 | status == 4 | status == 5
+	replace ocusec = 3 if status == 6
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>tan
+
+
+*<_industrycat_isic_>
+
+
+	gen industrycat_isic = industry_orig
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	gen occup_isco = occup_orig
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen occup = substr(occup_isco, 1, 1)
+	destring occup, replace
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen =  amount
+	replace wage_no_compen = . if amount == 99999
+	replace wage_no_compen = . if lstatus!=1
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = main_hr
+	replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>uni
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size== 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+
+/*<_t_hours_others_notes>
+
+</_t_hours_others_notes>*/
+
+	gen t_hours_others = total_hr - main_hr
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr== 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+ 
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2010_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q1 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2011 </_Data collection from_>
+<_Data collection to_>			March 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			76,500 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,436 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs541.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q1 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2011 </_Data collection from_>
+<_Data collection to_>			March 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			76,500 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,436 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q1\THA_2011_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q1\THA_2011_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs541.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "9999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -677,7 +677,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = re_ed
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q1/THA_2011_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q1 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2011 </_Data collection from_>
+<_Data collection to_>			March 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			76,500 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,436 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q1\THA_2011_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q1\THA_2011_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs541.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "9999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1756 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2011 </_Data collection from_>
+<_Data collection to_>			June 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,858 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,459 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs542.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+	
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2011 </_Data collection from_>
+<_Data collection to_>			June 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,858 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,459 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q2\THA_2011_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q2\THA_2011_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs542.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -671,7 +671,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = re_ed
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 
@@ -895,8 +895,8 @@ foreach v of local ed_var {
 *<_industry_orig_>
 	gen industry_orig = indus
 	tostring industry_orig, replace
-	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
-	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "9999"
 	label var industry_orig "Original survey industry code, main job 7 day recall"
 *</_industry_orig_>
 

--- a/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q2/THA_2011_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2011 </_Data collection from_>
+<_Data collection to_>			June 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,858 </_Sample size (HH)_>
+<_Sample size (IND)_> 			228,459 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q2\THA_2011_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q2\THA_2011_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs542.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2011 </_Data collection from_>
+<_Data collection to_>			September 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,980 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,216 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs543.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2011 </_Data collection from_>
+<_Data collection to_>			September 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,980 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,216 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q3\THA_2011_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q3\THA_2011_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs543.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2011 </_Data collection from_>
+<_Data collection to_>			September 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			79,980 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,216 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q3\THA_2011_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q3\THA_2011_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs543.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid no_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+*<_school_>
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "9999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	replace wage_no_compen = . if amount == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q3/THA_2011_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -676,7 +676,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = re_ed
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1759 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2011 </_Data collection from_>
+<_Data collection to_>			December 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,905 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2011_LFS\THA_2011_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs544.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(no)
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS_V01_M_V01_A_GLD_Q4.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2011 </_Data collection from_>
+<_Data collection to_>			December 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,905 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q4\THA_2011_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q4\THA_2011_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs544.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(no)
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2011_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2011 Q2 </_Survey Title_>
+<_Survey Year_>					2011 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2011 </_Data collection from_>
+<_Data collection to_>			December 2011 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			68,905 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,720 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 1997 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-07-11] - Updated ISCED version
+* Date: [2022-08-03] - Updated ISIC mapping
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q4\THA_2011_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2011_LFS-Q4\THA_2011_LFS-Q4_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs544.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_1997"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2011
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2011
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwt area psu_no hh_no no{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace psu_no_str = "0" + psu_no_str if length(psu_no_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace no_str =  "0" + no_str if length(no_str)==1
+
+
+	egen hhid = concat(reg_str cwt_str area_str psu_no_str hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(no)
+	egen pid = concat(hhid no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	drop weight
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+
+	egen psu = concat(reg_str cwt_str area_str psu_no_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwt_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwt
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	gen neg_age = -(age)
+	sort hhid sex neg_age no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace relation = 1 if hhorder==1 & tot_head!=1
+	replace relation = 5 if hhorder!=1 & relation ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = relation==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert relation == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = relation
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = relation
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+
+	gen byte school= (grade_a != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = re_ed
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+
+capture confirm variable edcode
+
+	if !_rc {
+		gen re_ed = edcode
+	}
+	
+	gen educat_isced = ""
+	replace educat_isced = "0" if re_ed == 2 
+	replace educat_isced = "1" if re_ed == 3 
+	replace educat_isced = "2A" if re_ed == 4 
+	replace educat_isced = "3A" if re_ed == 5 
+	replace educat_isced = "3B" if re_ed == 6 
+	replace educat_isced = "3A" if re_ed == 7 
+	replace educat_isced = "3C" if inrange(re_ed, 8, 10)
+	replace educat_isced = "5A" if inrange(re_ed, 11, 14)
+	replace educat_isced = "6" if re_ed == 15
+
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if wk_7day == 1 | return == 1 | receive == 1
+	replace lstatus = 2 if inrange(seeking, 1, 2) | available == 1
+	replace lstatus = 3 if (seeking == 3 & available == 2) | (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (seeking == 3 & available == 1) | (seeking == 2 & available == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & more_wk == 1
+	replace underemployment = 0 if lstatus == 1 & more_wk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if re_unavail == 2
+	replace nlfreason = 2 if re_unavail == 1
+	replace nlfreason = 3 if re_unavail == 7
+	replace nlfreason = 4 if re_unavail == 5
+	replace nlfreason = 5 if re_unavail == 3 | re_unavail == 4 | re_unavail == 7 | re_unavail == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if status == 4 | status == 5 | status == 6
+	replace empstat = 2 if status == 3
+	replace empstat = 3 if status == 1
+	replace empstat = 4 if status == 2
+	replace empstat = 5 if status == 7 | status == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if status == 4
+	replace ocusec = 2 if status == 1 | status == 2 | status == 3 | status == 6 | status == 7 | status == 8
+	replace ocusec = 3 if status == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indus
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 3
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "9999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+*<_industrycat_isic_>
+
+	merge m:1 industry_orig using "$path_in\TSIC4d_to_ISIC_v3.dta", keep(master match) nogen 
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring occup, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = amount
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if wage_type == 2
+	replace unitwage = 2 if wage_type == 3
+	replace unitwage = 5 if wage_type == 4
+	replace unitwage = 6 if wage_type == 5
+	replace unitwage = 9 if wage_type == 1
+	replace unitwage = . if wage_type == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = main_hr
+replace whours = . if main_hr == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if size == 1
+	replace firmsize_l = 5 if size == 2
+	replace firmsize_l = 10 if size == 3
+	replace firmsize_l = 20 if size == 4
+	replace firmsize_l = 50 if size == 5
+	replace firmsize_l = 100 if size == 6
+	replace firmsize_l = 200 if size == 7
+	replace firmsize_l = . if size == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if size == 1
+	replace firmsize_u = 9 if size == 2
+	replace firmsize_u = 19 if size == 3
+	replace firmsize_u = 49 if size == 4
+	replace firmsize_u = 99 if size == 5
+	replace firmsize_u = 199 if size == 6
+	replace firmsize_u = . if size == 7
+	replace firmsize_u = . if size == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = total_hr
+	replace t_hours_total = . if total_hr == 0 | (total_hr>140 & !missing(total_hr))
+	replace t_hours_total = t_hours_total * 52 
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2011_LFS-Q4_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2011_LFS-Q4/THA_2011_LFS-Q4_v01_M_v03_A_GLD/Programs/THA_2011_LFS-Q4_v01_M_v03_A_GLD_ALL.do
@@ -676,7 +676,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = re_ed
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q1 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2012 </_Data collection from_>
+<_Data collection to_>			March 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,885 </_Sample size (HH)_>
+<_Sample size (IND)_> 			218,074 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file	
+	
+* The file "lfs551.dta" does not contain enough information to create a unique ID variable so we use "lfs551tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs551tdri.dta", clear
+	
+* Dropping the missing cases. Around 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 51
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	egen pid = concat(hhid line_no)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage add_hwk{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS_V01_M_V01_A_GLD_Q1.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q1 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2012 </_Data collection from_>
+<_Data collection to_>			March 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,885 </_Sample size (HH)_>
+<_Sample size (IND)_> 			218,074 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q1\THA_2012_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q1\THA_2012_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file	
+	
+* The file "lfs551.dta" does not contain enough information to create a unique ID variable so we use "lfs551tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs551tdri.dta", clear
+	
+* Dropping the missing cases. Around 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 51
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	egen pid = concat(hhid line_no)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage add_hwk{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -690,7 +690,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q1/THA_2012_LFS-Q1_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q1_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1784 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q1 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2012 </_Data collection from_>
+<_Data collection to_>			March 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,885 </_Sample size (HH)_>
+<_Sample size (IND)_> 			218,074 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q1\THA_2012_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q1\THA_2012_LFS-Q1_v01_M_v03_A_GLD\Data\Harmonized"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file	
+	
+* The file "lfs551.dta" does not contain enough information to create a unique ID variable so we use "lfs551tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs551tdri.dta", clear
+	
+* Dropping the missing cases. Around 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 51
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	egen pid = concat(hhid line_no)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+}
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage add_hwk{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q1_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1792 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q2 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2012 </_Data collection from_>
+<_Data collection to_>			June 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,536 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,889 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs552.dta" does not contain enough information to create a unique ID variable so we use "lfs552tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs552tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 45
+
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk receive dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS_V01_M_V01_A_GLD_Q2.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1792 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q2 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2012 </_Data collection from_>
+<_Data collection to_>			June 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,536 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,889 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q2\THA_2012_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q2\THA_2012_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs552.dta" does not contain enough information to create a unique ID variable so we use "lfs552tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs552tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 45
+
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk receive dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1801 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q2 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2012 </_Data collection from_>
+<_Data collection to_>			June 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,536 </_Sample size (HH)_>
+<_Sample size (IND)_> 			226,889 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q2\THA_2012_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q2\THA_2012_LFS-Q2_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs552.dta" does not contain enough information to create a unique ID variable so we use "lfs552tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs552tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(sex - yround)
+	tab no_info
+
+drop if no_info == 45
+
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk receive dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q2_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q2/THA_2012_LFS-Q2_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q2_v01_M_v03_A_GLD_ALL.do
@@ -707,7 +707,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1797 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q3 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2012 </_Data collection from_>
+<_Data collection to_>			September 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,709 </_Sample size (HH)_>
+<_Sample size (IND)_> 			239,313 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M\Data\Stata"
+
+global path_output "C:\Users\wb510859\OneDrive - WBG\GLD-Harmonization\510859_AS\THA\THA_2012_LFS\THA_2012_LFS_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs553.dta" does not contain enough information to create a unique ID variable so we use "lfs553tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs553tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(listing - yround)
+	tab no_info
+
+drop if no_info >= 66
+
+* Look at cases with missing weight. Drop this as well since it is not counted in pop estimates and does not contain substantial information
+count if no_info == 65 & missing(wt)
+drop if missing(wt)
+
+
+	/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk dr_unem receive wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS_V01_M_V01_A_GLD_Q3.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1797 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q3 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2012 </_Data collection from_>
+<_Data collection to_>			September 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,709 </_Sample size (HH)_>
+<_Sample size (IND)_> 			239,313 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q3\THA_2012_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q3\THA_2012_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs553.dta" does not contain enough information to create a unique ID variable so we use "lfs553tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs553tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(listing - yround)
+	tab no_info
+
+drop if no_info >= 66
+
+* Look at cases with missing weight. Drop this as well since it is not counted in pop estimates and does not contain substantial information
+count if no_info == 65 & missing(wt)
+drop if missing(wt)
+
+
+	/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk dr_unem receive wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -714,7 +714,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v03_A_GLD_ALL.do
+++ b/GLD/THA/THA_2012_LFS-Q3/THA_2012_LFS-Q3_v01_M_v03_A_GLD/Programs/THA_2012_LFS-Q3_v01_M_v03_A_GLD_ALL.do
@@ -1,0 +1,1805 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2012_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2012 Q3 </_Survey Title_>
+<_Survey Year_>					2012 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2012 </_Data collection from_>
+<_Data collection to_>			September 2012 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,709 </_Sample size (HH)_>
+<_Sample size (IND)_> 			239,313 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+*----------1.1: Initial commands------------------------------*
+
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q3\THA_2012_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2012_LFS-Q3\THA_2012_LFS-Q3_v01_M_v03_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+* The file "lfs553.dta" does not contain enough information to create a unique ID variable so we use "lfs553tdri.dta". Moreover, the 5-digit industry codes here are consistent with the later years and the population estimate is close to official NSO reports.
+
+	use "$path_in\lfs553tdri.dta", clear
+	
+* Dropping the missing cases. More than 10K observations have missing values in all columns aside from the geographic information 
+
+	egen no_info = rowmiss(listing - yround)
+	tab no_info
+
+drop if no_info >= 66
+
+* Look at cases with missing weight. Drop this as well since it is not counted in pop estimates and does not contain substantial information
+count if no_info == 65 & missing(wt)
+drop if missing(wt)
+
+
+	/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2012
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V03"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2012
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pidtemp = concat(hhid line_no)
+	duplicates tag pidtemp, gen(tag)
+	
+	destring age, gen(neg_age)
+	replace neg_age = -(neg_age)
+	
+	
+	sort hhid sex neg_age
+	
+	drop neg_age
+	by hhid: gen line_no_fix = _n
+	
+	egen pidnew = concat(hhid line_no_fix)
+
+	gen pid = pidtemp if tag==0
+	replace pid = pidnew if tag== 1
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour reunwk dr_unem receive wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	replace industrycat_isic = "" if industrycat_isic == "n/a"
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industry	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2012_LFS-Q3_v01_M_v03_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q1 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2014 </_Data collection from_>
+<_Data collection to_>			March 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,972 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,176 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q1\THA_2014_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q1\THA_2014_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs571tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no = "02" if hhid== "44410433A01" & rela!="0"
+
+	egen pid = concat(hhid line_no)
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk receive lookwk add_hwk tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1777 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q1 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2014 </_Data collection from_>
+<_Data collection to_>			March 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,972 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,176 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q1\THA_2014_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q1\THA_2014_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs571tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no =  "0" + line_no if length(line_no)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no = "02" if hhid== "44410433A01" & rela!="0"
+
+	egen pid = concat(hhid line_no)
+	isid pid
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	destring wt, gen(weight)
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk receive lookwk add_hwk tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q1/THA_2014_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -688,7 +688,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q2 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2014 </_Data collection from_>
+<_Data collection to_>			June 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,983 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,556 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q2\THA_2014_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q2\THA_2014_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs572tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pid = concat(hhid line_no)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk receive add_hwk tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -674,7 +674,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q2/THA_2014_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q2 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2014 </_Data collection from_>
+<_Data collection to_>			June 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,983 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,556 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q2\THA_2014_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q2\THA_2014_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs572tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	egen pid = concat(hhid line_no)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+
+/*<_gaul_adm_code_notes>
+
+	Based on the EAPLAB codes, the gaul_adm1 and gaul_adm2 are region and province respectively
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = .
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk receive add_hwk tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1759 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q3 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2014 </_Data collection from_>
+<_Data collection to_>			September 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,390 </_Sample size (HH)_>
+<_Sample size (IND)_> 			232,710 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q3\THA_2014_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q3\THA_2014_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs573tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no_str ="02" if (hhid == "59510503C01" | hhid == "59510503D01")  & rela == 0
+
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk  receive tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -681,7 +681,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q3/THA_2014_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1770 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q3 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2014 </_Data collection from_>
+<_Data collection to_>			September 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,390 </_Sample size (HH)_>
+<_Sample size (IND)_> 			232,710 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q3\THA_2014_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q3\THA_2014_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs573tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no_str ="02" if (hhid == "59510503C01" | hhid == "59510503D01")  & rela == 0
+
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk  receive tothour reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q4 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2014 </_Data collection from_>
+<_Data collection to_>			December 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,820 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,582 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q4\THA_2014_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q4\THA_2014_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs574tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no_str ="02" if (hhid == "59510503C01" | hhid == "59510503D01")  & rela == 0
+
+	egen pid = concat(hhid line_no_str)
+	isid pid
+	
+	label var pid "Individual ID"
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2014_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2014 Q4 </_Survey Title_>
+<_Survey Year_>					2014 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2014 </_Data collection from_>
+<_Data collection to_>			December 2014 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,820 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,582 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q4\THA_2014_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2014_LFS-Q4\THA_2014_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs574tdri.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	drop year
+	gen int year = 2014
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2014
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv rota_gr hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str rota_gr_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	replace line_no_str ="02" if (hhid == "59510503C01" | hhid == "59510503D01")  & rela == 0
+
+	egen pid = concat(hhid line_no_str)
+	isid pid
+	
+	label var pid "Individual ID"
+
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	destring sex, replace
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+	destring rela, replace
+	drop if missing(rela)
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	drop if missing(rela)
+	
+	destring age, replace
+	gen neg_age = -(age)
+	sort hhid sex neg_age line_no
+	by hhid: gen hhorder = _n
+	replace hhorder = . if hhorder!=1
+	
+	replace rela = 1 if hhorder==1 & tot_head!=1
+	replace rela = 5 if hhorder!=1 & rela ==1 & tot_head!=1
+	
+	drop head tot_head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2014_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2014_LFS-Q4/THA_2014_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2014_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -686,7 +686,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1750 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,820 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,582 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q1\THA_2015_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q1\THA_2015_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs581tdri.dta", clear
+
+
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -665,7 +665,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = edcode
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q1/THA_2015_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,820 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,582 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q1\THA_2015_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q1\THA_2015_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs581tdri.dta", clear
+
+
+
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	drop year
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = month
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- reg (Region)
+	- cwd (Province)
+	- area (Urban/Rural)
+	- blkv (Primary sampling unit)
+	- samset (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist reg cwd area blkv hh_no line_no {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace blkv_str = "0" + blkv_str if length(blkv_str)==2
+	replace hh_no_str =  "0" + hh_no_str if length(hh_no_str)==1
+	replace line_no_str =  "0" + line_no_str if length(line_no_str)==1
+
+
+	egen hhid = concat(reg_str cwd_str area_str blkv_str samset hh_no_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid line_no_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = wt
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(reg_str cwd_str area_str blkv_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = cwd_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = area
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = reg
+	
+		label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = cwd
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+			
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = sex
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = rela==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	assert rela == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = rela
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = rela
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring mrstat, replace
+	gen  marital = mrstat
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring studylev, replace
+	
+	gen byte school= (studylev!=1)
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	destring edcode, gen(edcode_n)
+	gen byte educat7 = edcode_n
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if edcode_n == 2
+	replace educat_isced = "100" if edcode_n == 3
+	replace educat_isced = "244" if edcode_n == 4
+	replace educat_isced = "344" if inrange(edcode_n, 5, 7)
+	replace educat_isced = "354" if edcode_n == 8
+	replace educat_isced = "550" if edcode_n == 9
+	replace educat_isced = "540" if edcode_n == 10
+	replace educat_isced = "660" if inrange(edcode_n, 11, 13)
+	replace educat_isced = "760" if edcode_n == 14
+	replace educat_isced = "860" if edcode_n == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+* Destring all string categorical variables
+foreach var of varlist wklw perjob avaiwk lookwk add_hwk tothour receive reunwk dr_unem wkstat baht firmsize hour_po twage{
+	  destring `var', replace
+	}
+
+*<_lstatus_>
+
+	gen byte lstatus = 1 if wklw == 1 | perjob == 1 | receive == 1
+	replace lstatus = 2 if lookwk == 1 | (lookwk == 2 & avaiwk == 1)
+	replace lstatus = 3 if (lookwk == 3 & avaiwk == 2) | (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace lstatus = . if age < minlaborage
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (lookwk == 3 & avaiwk == 1) | (lookwk == 2 & avaiwk == 2)
+	replace potential_lf = . if age < minlaborage & age != .
+	replace potential_lf = . if lstatus != 3
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring add_hwk, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & add_hwk == 1
+	replace underemployment = 0 if lstatus == 1 & add_hwk == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason =.
+	replace nlfreason = 1 if reunwk == 2
+	replace nlfreason = 2 if reunwk == 1
+	replace nlfreason = 3 if reunwk == 7
+	replace nlfreason = 4 if reunwk == 5
+	replace nlfreason = 5 if reunwk == 3 | reunwk == 4 | reunwk == 7 | reunwk == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if dr_unem == 1
+	replace unempldur_l = 1 if dr_unem == 2
+	replace unempldur_l = 3 if dr_unem == 3
+	replace unempldur_l = 6 if dr_unem == 4
+	replace unempldur_l = 9 if dr_unem == 5
+	replace unempldur_l = 11.9 if dr_unem == 6
+	replace unempldur_l = . if dr_unem == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if dr_unem == 1
+	replace unempldur_u = 2.9 if dr_unem == 2
+	replace unempldur_u = 5.9 if dr_unem == 3
+	replace unempldur_u = 8.9 if dr_unem == 4
+	replace unempldur_u = 11.9 if dr_unem == 5
+	replace unempldur_u = . if dr_unem == 6
+	replace unempldur_u = . if dr_unem == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if wkstat == 4 | wkstat == 5 | wkstat == 6
+	replace empstat = 2 if wkstat == 3
+	replace empstat = 3 if wkstat == 1
+	replace empstat = 4 if wkstat == 2
+	replace empstat = 5 if wkstat == 7 | wkstat == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if wkstat == 4
+	replace ocusec = 2 if wkstat == 1 | wkstat == 2 | wkstat == 3 | wkstat == 6 | wkstat == 7 | wkstat == 8
+	replace ocusec = 3 if wkstat == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = indust
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match) nogen
+	gen industrycat_isic = ISIC_v3
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = occup
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	drop occup
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = baht
+	replace wage_no_compen = . if baht == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if twage == 2
+	replace unitwage = 2 if twage == 3
+	replace unitwage = 5 if twage == 4
+	replace unitwage = 6 if twage == 5
+	replace unitwage = 9 if twage == 1
+	replace unitwage = . if twage == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = hour_po
+	replace whours = . if  hour_po == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if firmsize == 1
+	replace firmsize_l = 5 if firmsize == 2
+	replace firmsize_l = 10 if firmsize == 3
+	replace firmsize_l = 20 if firmsize == 4
+	replace firmsize_l = 50 if firmsize == 5
+	replace firmsize_l = 100 if firmsize == 6
+	replace firmsize_l = 200 if firmsize == 7
+	replace firmsize_l = . if firmsize == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if firmsize == 1
+	replace firmsize_u = 9 if firmsize == 2
+	replace firmsize_u = 19 if firmsize == 3
+	replace firmsize_u = 49 if firmsize == 4
+	replace firmsize_u = 99 if firmsize == 5
+	replace firmsize_u = 199 if firmsize == 6
+	replace firmsize_u = . if firmsize == 7
+	replace firmsize_u = . if firmsize == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = tothour
+	replace t_hours_total = . if tothour == 0 | (tothour > 140 & !missing(tothour))
+	replace t_hours_total = t_hours_total * 52
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1755 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2015 </_Data collection from_>
+<_Data collection to_>			June 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,502 </_Sample size (HH)_>
+<_Sample size (IND)_> 			218,289 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q2\THA_2015_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q2\THA_2015_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs582.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2015 </_Data collection from_>
+<_Data collection to_>			June 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,502 </_Sample size (HH)_>
+<_Sample size (IND)_> 			218,289 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q2\THA_2015_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q2\THA_2015_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs582.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+
+* Based on Thai NSO, employed are those who worked at least one hour in the past week, or did not work but receive salary/wage, not receive wagebut had regular job, or worked at least 1 hour without pay in business enterprises
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q2/THA_2015_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -666,7 +666,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1749 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,086 </_Sample size (HH)_>
+<_Sample size (IND)_> 			229,332 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q3\THA_2015_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q3\THA_2015_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs583.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -664,7 +664,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q3/THA_2015_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1755 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,086 </_Sample size (HH)_>
+<_Sample size (IND)_> 			229,332 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q3\THA_2015_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q3\THA_2015_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs583.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1754 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,068 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,433 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q4\THA_2015_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q4\THA_2015_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs584.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -667,7 +667,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2015_LFS-Q4/THA_2015_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2015_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2015_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-01-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2015 Q1 </_Survey Title_>
+<_Survey Year_>					2015 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2015 </_Data collection from_>
+<_Data collection to_>			March 2015 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,068 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,433 </_Sample size (IND)_>
+<_Sampling method_> 			
+
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				ICLS 13 </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-01-08] - Prepared initial code
+* Date: [2022-06-15] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q4\THA_2015_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2015_LFS-Q4\THA_2015_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs584.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2015
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2015
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Enumeration area)
+	- SAMSET (Sample set)
+	- hh_no  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO{
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==2
+	replace HH_NO_str =  "0" + HH_NO_str if length(HH_NO_str)==1
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	*drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid pid
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	bys hhid: gen hsize = _N	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* The households with missing HH heads are "special household members"
+	
+	gen relationharm = RELATION
+	
+	* Set missing as missing the "special household members" as they consistent a very small proportion of the total observations
+	recode relationharm (3 4 = 3) (6 8 = 5) (7 = 4) (9 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = RELATION
+	label de lblrelationcs 1 "Household's head" 2 "Houseband/wife" 3  "Unmarried children" 4 "Married children" 5 "Spouse of married children" 6 "Grand children" 7 "Parents, parents-in-law" 8 "Other relatives" 9 "Non-relative, servants" 0 "Special household member"
+	label values relationcs  lblrelationcs
+
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, replace
+	gen  marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	* There is an extremely small # cases of code 6 "married but unknown status". I set this to missing
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 and older.
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+
+* Note: edcode = 16 refers to short courses that are not comparable with education categories. These are left missing along with edcode = 17 "unknown education". Both comprise less than 1% of total observations
+
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7 = 5) (8 9 10 = 6) (11 12 13 14 15 = 7) (16 17 = .)
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen nlfreason = .
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 4 | RE_UNAVAIL == 7 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(occup_orig)
+	replace occup_orig = "" if lstatus!=1 
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = occup_orig
+	replace occup_isco = "" if occup_orig == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(occup_orig, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2015_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1761 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q1 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2016 </_Data collection from_>
+<_Data collection to_>			March 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,035 </_Sample size (HH)_>
+<_Sample size (IND)_> 			212,216 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q1\THA_2016_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q1\THA_2016_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs591.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -672,7 +672,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q1/THA_2016_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q1 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2016 </_Data collection from_>
+<_Data collection to_>			March 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,035 </_Sample size (HH)_>
+<_Sample size (IND)_> 			212,216 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+</_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q1\THA_2016_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q1\THA_2016_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs591.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q2 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2016 </_Data collection from_>
+<_Data collection to_>			June 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,218 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,055 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q2\THA_2016_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q2\THA_2016_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs592.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1771 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q2 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2016 </_Data collection from_>
+<_Data collection to_>			June 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,218 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,055 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q2\THA_2016_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q2\THA_2016_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs592.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q2/THA_2016_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -673,7 +673,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1762 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q3 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2016 </_Data collection from_>
+<_Data collection to_>			September 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,770 </_Sample size (HH)_>
+<_Sample size (IND)_> 			230,798 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q3\THA_2016_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q3\THA_2016_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs593.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = totfam_size
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -674,7 +674,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q3/THA_2016_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q3 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2016 </_Data collection from_>
+<_Data collection to_>			September 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,770 </_Sample size (HH)_>
+<_Sample size (IND)_> 			230,798 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q3\THA_2016_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q3\THA_2016_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs593.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = totfam_size
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1764 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q4 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2016 </_Data collection from_>
+<_Data collection to_>			December 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,949 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,997 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q4\THA_2016_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q4\THA_2016_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs594.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = MEMBERS
+
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1771 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2016_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2016 Q4 </_Survey Title_>
+<_Survey Year_>					2016 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2016 </_Data collection from_>
+<_Data collection to_>			December 2016 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,949 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,997 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-16-10] - Prepared initial code
+* Date: [2022-05-31] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q4\THA_2016_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2016_LFS-Q4\THA_2016_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs594.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2016
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2016
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+
+}
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	gen hsize = MEMBERS
+
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year =.
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = TOTAL_HR
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2016_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2016_LFS-Q4/THA_2016_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2016_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -673,7 +673,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q1 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2017 </_Data collection from_>
+<_Data collection to_>			March 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,113 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,482 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q1\THA_2017_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q1\THA_2017_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs601.dta", clear
+	
+	* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q1 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2017 </_Data collection from_>
+<_Data collection to_>			March 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,113 </_Sample size (HH)_>
+<_Sample size (IND)_> 			207,482 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q1\THA_2017_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q1\THA_2017_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs601.dta", clear
+	
+	* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+ 
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q1/THA_2017_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -672,7 +672,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1778 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q2 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2017 </_Data collection from_>
+<_Data collection to_>			June 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,332 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,256 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q2\THA_2017_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q2\THA_2017_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs602.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q2 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2017 </_Data collection from_>
+<_Data collection to_>			June 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,332 </_Sample size (HH)_>
+<_Sample size (IND)_> 			219,256 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q2\THA_2017_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q2\THA_2017_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs602.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q2/THA_2017_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -676,7 +676,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1796 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q3 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2017 </_Data collection from_>
+<_Data collection to_>			September 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,456 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,229 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q3\THA_2017_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q3\THA_2017_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs603.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+	* There is a case wherein a household has two household heads
+	* As a rule, we assign the older male as the household head
+	* Other heads sent to value 5, coded as "Other relatives"
+
+	replace RELATION = 5 if tot_head > 1 & SEX !=1
+	
+	* Case when there is no household head
+	bys hhid: egen max_age = max(age)
+	replace RELATION = 1 if tot_head !=1 & SEX==1 & AGE == max_age & RELATION != 0
+	
+	gen head2 = RELATION == 1
+	bys hhid: egen tot_head2 = sum(head2)
+	
+	assert RELATION == 0 if tot_head2!=1
+	* The households with missing HH heads are 
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -694,7 +694,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q3/THA_2017_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1803 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q3 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2017 </_Data collection from_>
+<_Data collection to_>			September 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,456 </_Sample size (HH)_>
+<_Sample size (IND)_> 			227,229 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q3\THA_2017_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q3\THA_2017_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs603.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+	* There is a case wherein a household has two household heads
+	* As a rule, we assign the older male as the household head
+	* Other heads sent to value 5, coded as "Other relatives"
+
+	replace RELATION = 5 if tot_head > 1 & SEX !=1
+	
+	* Case when there is no household head
+	bys hhid: egen max_age = max(age)
+	replace RELATION = 1 if tot_head !=1 & SEX==1 & AGE == max_age & RELATION != 0
+	
+	gen head2 = RELATION == 1
+	bys hhid: egen tot_head2 = sum(head2)
+	
+	assert RELATION == 0 if tot_head2!=1
+	* The households with missing HH heads are 
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q4 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2017 </_Data collection from_>
+<_Data collection to_>			December 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,788 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,746 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q4\THA_2017_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q4\THA_2017_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs604.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -677,7 +677,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2017_LFS-Q4/THA_2017_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2017_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1783 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2017_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2017 Q4 </_Survey Title_>
+<_Survey Year_>					2017 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2017 </_Data collection from_>
+<_Data collection to_>			December 2017 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,788 </_Sample size (HH)_>
+<_Sample size (IND)_> 			213,746 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q4\THA_2017_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2017_LFS-Q4\THA_2017_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs604.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2017
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2017
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2017_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q1 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2018 </_Data collection from_>
+<_Data collection to_>			March 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,738 </_Sample size (HH)_>
+<_Sample size (IND)_> 			202,450 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q1\THA_2018_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q1\THA_2018_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs611.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -677,7 +677,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q1/THA_2018_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q1 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2018 </_Data collection from_>
+<_Data collection to_>			March 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,738 </_Sample size (HH)_>
+<_Sample size (IND)_> 			202,450 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q1\THA_2018_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q1\THA_2018_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs611.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	
+gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q2 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2018 </_Data collection from_>
+<_Data collection to_>			June 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,428 </_Sample size (HH)_>
+<_Sample size (IND)_> 			214,949 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q2\THA_2018_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q2\THA_2018_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs612.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+   
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q2 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2018 </_Data collection from_>
+<_Data collection to_>			June 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,428 </_Sample size (HH)_>
+<_Sample size (IND)_> 			214,949 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q2\THA_2018_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q2\THA_2018_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs612.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+   
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q2/THA_2018_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -676,7 +676,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q3 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2018 </_Data collection from_>
+<_Data collection to_>			September 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,560 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,537 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q3\THA_2018_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q3\THA_2018_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs613.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1767 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q3 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2018 </_Data collection from_>
+<_Data collection to_>			September 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,560 </_Sample size (HH)_>
+<_Sample size (IND)_> 			222,537 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q3\THA_2018_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q3\THA_2018_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs613.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q3/THA_2018_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -675,7 +675,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q4 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2018 </_Data collection from_>
+<_Data collection to_>			December 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,204 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,747 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q4\THA_2018_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q4\THA_2018_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs614.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen (marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1772 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2018_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2018 Q4 </_Survey Title_>
+<_Survey Year_>					2018 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2018 </_Data collection from_>
+<_Data collection to_>			December 2018 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,204 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,747 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q4\THA_2018_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2018_LFS-Q4\THA_2018_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs614.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2018
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2018
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen (marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, â€¦)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if (MAIN_HR>84 & !missing(MAIN_HR)) | MAIN_HR == 0
+
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = .
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+    
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat10 occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2018_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2018_LFS-Q4/THA_2018_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2018_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -674,7 +674,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q1 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2019 </_Data collection from_>
+<_Data collection to_>			March 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2019-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q1\THA_2019_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q1\THA_2019_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs621.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1786 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q1 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2019 </_Data collection from_>
+<_Data collection to_>			March 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,513 </_Sample size (HH)_>
+<_Sample size (IND)_> 			201,976 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2019-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q1\THA_2019_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q1\THA_2019_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs621.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q1/THA_2019_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -675,7 +675,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q2 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2019 </_Data collection from_>
+<_Data collection to_>			June 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,155 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,335 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q2\THA_2019_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q2\THA_2019_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs622.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -672,7 +672,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q2/THA_2019_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1777 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q2 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2019 </_Data collection from_>
+<_Data collection to_>			June 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,155 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,335 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q2\THA_2019_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q2\THA_2019_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs622.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	destring MARITAL, gen(marital)
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	destring WK_7DAY, replace
+	destring RETURN, replace
+	destring AVAILABLE, replace
+	destring RE_UNAVAIL, replace
+	destring DR_UNEM, replace
+	destring STATUS, replace
+	destring SEEKING, replace
+	destring WAGE_TYPE, replace
+	destring AMOUNT, replace
+	destring MAIN_HR, replace
+	destring TOTAL_HR, replace
+	destring SIZE, replace
+	destring RECEIVE, replace
+	
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	gen occup_orig = OCCUP
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP
+	replace occup_isco = "" if OCCUP == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1766 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q3 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2019 </_Data collection from_>
+<_Data collection to_>			September 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,103 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,707 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q3\THA_2019_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q3\THA_2019_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs623.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+	
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+	* In this dataset, one record is duplicated: i.e., same values across all variables with the exception of line number
+	drop if pid == "352101469D302"
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -679,7 +679,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q3/THA_2019_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1771 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q3 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2019 </_Data collection from_>
+<_Data collection to_>			September 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,103 </_Sample size (HH)_>
+<_Sample size (IND)_> 			215,707 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q3\THA_2019_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q3\THA_2019_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs623.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+	
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+	* In this dataset, one record is duplicated: i.e., same values across all variables with the exception of line number
+	drop if pid == "352101469D302"
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q4 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2019 </_Data collection from_>
+<_Data collection to_>			December 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,895 </_Sample size (HH)_>
+<_Sample size (IND)_> 			205,256 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q4\THA_2019_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q4\THA_2019_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs624.dta", clear
+	
+
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -677,7 +677,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2019_LFS-Q4/THA_2019_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2019_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2019_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2019 Q4 </_Survey Title_>
+<_Survey Year_>					2019 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2019 </_Data collection from_>
+<_Data collection to_>			December 2019 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,895 </_Sample size (HH)_>
+<_Sample size (IND)_> 			205,256 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q4\THA_2019_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2019_LFS-Q4\THA_2019_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs624.dta", clear
+	
+
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2019
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2019
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	
+	label var pid "Individual ID"
+*</_pid_>
+
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+
+
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	destring GRADE_A, replace
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	destring RE_ED, replace
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	destring MORE_WK, replace
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2019_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1765 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2020-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q1 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2020 </_Data collection from_>
+<_Data collection to_>			March 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,502 </_Sample size (HH)_>
+<_Sample size (IND)_> 			199,641 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2020-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q1\THA_2020_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q1\THA_2020_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs631.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+	
+	
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1769 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2020-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q1 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2020 </_Data collection from_>
+<_Data collection to_>			March 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,502 </_Sample size (HH)_>
+<_Sample size (IND)_> 			199,641 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2020-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q1\THA_2020_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q1\THA_2020_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs631.dta", clear
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+	
+	
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q1/THA_2020_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -675,7 +675,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1776 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q2 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2020 </_Data collection from_>
+<_Data collection to_>			June 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,970 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,175 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q2\THA_2020_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q2\THA_2020_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs632.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -686,7 +686,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q2/THA_2020_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1781 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q2.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q2 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2020 </_Data collection from_>
+<_Data collection to_>			June 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,970 </_Sample size (HH)_>
+<_Sample size (IND)_> 			210,175 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q2\THA_2020_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q2\THA_2020_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs632.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+
+
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q3 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2020 </_Data collection from_>
+<_Data collection to_>			September 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,892 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,672 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q3\THA_2020_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q3\THA_2020_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs633.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -677,7 +677,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q3/THA_2020_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1773 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q3 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2020 </_Data collection from_>
+<_Data collection to_>			September 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,892 </_Sample size (HH)_>
+<_Sample size (IND)_> 			220,672 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q3\THA_2020_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q3\THA_2020_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs633.dta", clear
+	
+* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1768 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q4 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2020 </_Data collection from_>
+<_Data collection to_>			December 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,973 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,671 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q4\THA_2020_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q4\THA_2020_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs634.dta", clear
+	
+	* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -678,7 +678,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2020_LFS-Q4/THA_2020_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2020_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1774 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2020_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2020 Q4 </_Survey Title_>
+<_Survey Year_>					2020 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2020 </_Data collection from_>
+<_Data collection to_>			December 2020 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			72,973 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,671 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q4\THA_2020_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2020_LFS-Q4\THA_2020_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+
+
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs634.dta", clear
+	
+	* Rename variables such that unnecessary suffix is removed
+rename (*_) (*)
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2020
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2020
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	isid(pid)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = Weight
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+
+	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2020_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1755 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q1 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2021 </_Data collection from_>
+<_Data collection to_>			March 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,981 </_Sample size (HH)_>
+<_Sample size (IND)_> 			200,956 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q1\THA_2021_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q1\THA_2021_LFS-Q1_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs641.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = WGT_CWT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	replace occup_orig = "" if occup_orig == "."
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	replace occup_isco = "" if OCCUP_STR == "."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q1_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -667,7 +667,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q1/THA_2021_LFS-Q1_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q1_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1760 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q1.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2021-12-08 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q1 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		January 2021 </_Data collection from_>
+<_Data collection to_>			March 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,981 </_Sample size (HH)_>
+<_Sample size (IND)_> 			200,956 </_Sample size (IND)_>
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2021-12-08] - Prepared initial code
+* Date: [2022-05-30] - Added codes that harmonize data for specific variables, including school attendance, ISCO and ISIC codes, etc...
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q1\THA_2021_LFS-Q1_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q1\THA_2021_LFS-Q1_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs641.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+/*<_pid_note>
+
+	Some filtering of observations may be needed. The variable NO, which is a 
+	runner for individuals is missing in a total of 9,577 cases.
+	
+	I drop these as they also happen to not contain any other useful information.
+
+<_pid_note>*/
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = WGT_CWT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q1"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	* There are 153 cases with zero HH head
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = .)
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)	
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	replace occup_orig = "" if occup_orig == "."
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	replace occup_isco = "" if OCCUP_STR == "."
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q1_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1745 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2021 </_Data collection from_>
+<_Data collection to_>			June 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,865 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,894 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q2\THA_2021_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q2\THA_2021_LFS-Q2_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs642.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = WGT_REG
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	gen hsize = totfam_size
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	drop if isic_1d == "n"
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat* occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q2_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1749 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		April 2021 </_Data collection from_>
+<_Data collection to_>			June 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			74,865 </_Sample size (HH)_>
+<_Sample size (IND)_> 			209,894 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q2\THA_2021_LFS-Q2_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q2\THA_2021_LFS-Q2_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs642.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+	* Note rather than this is an individual sampling weight rather than HH
+	
+	gen weight = WGT_REG
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q2"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	gen hsize = totfam_size
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	drop if isic_1d == "n"
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+	
+	* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec industry_orig industrycat_isic industrycat* occup_orig occup occup_isco firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q2_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q2/THA_2021_LFS-Q2_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q2_v01_M_v02_A_GLD_ALL.do
@@ -655,7 +655,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1745 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2021 </_Data collection from_>
+<_Data collection to_>			September 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,286 </_Sample size (HH)_>
+<_Sample size (IND)_> 			206,991 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q3\THA_2021_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q3\THA_2021_LFS-Q3_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs643.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+
+	gen weight = WGT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	ren SIZE_ SIZE
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q3_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -657,7 +657,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q3/THA_2021_LFS-Q3_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q3_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1750 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q3.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		July 2021 </_Data collection from_>
+<_Data collection to_>			September 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,286 </_Sample size (HH)_>
+<_Sample size (IND)_> 			206,991 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q3\THA_2021_LFS-Q3_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q3\THA_2021_LFS-Q3_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs643.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+
+	gen weight = WGT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q3"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	ren SIZE_ SIZE
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+{
+*<_% Correction min age_>
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q3_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v01_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v01_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v01_A_GLD_ALL.do
@@ -1,0 +1,1746 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2021 </_Data collection from_>
+<_Data collection to_>			December 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			217,471 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q4\THA_2021_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q4\THA_2021_LFS-Q4_v01_M_v01_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs644.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V01"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+
+	gen weight = WGT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+*</_subnatid2_prev_>
+
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if isic_1d == 1
+	replace industrycat10 = 3 if isic_1d == 2 | isic_1d == 3
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_1d == 7
+	replace industrycat10 = 10 if inrange(isic_1d, 8, 9)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	ren SIZE_ SIZE
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q4_v01_M_v01_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>

--- a/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -658,7 +658,7 @@ label var ed_mod_age "Education module application age"
 
 
 *<_educat_orig_>
-	gen educat_orig = .
+	gen educat_orig = RE_ED
 	label var educat_orig "Original survey education code"
 *</_educat_orig_>
 

--- a/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v02_A_GLD_ALL.do
+++ b/GLD/THA/THA_2021_LFS-Q4/THA_2021_LFS-Q4_v01_M_v02_A_GLD/Programs/THA_2021_LFS-Q4_v01_M_v02_A_GLD_ALL.do
@@ -1,0 +1,1752 @@
+
+
+/*%%=============================================================================================
+	0: GLD Harmonization Preamble
+==============================================================================================%%*/
+
+/* -----------------------------------------------------------------------
+<_Program name_>				THA_2021_LFS_v01_M_v01_A_Q4.do </_Program name_>
+<_Application_>					Stata 17 <_Application_>
+<_Author(s)_>					World Bank Jobs Group (gld@worldbank.org) </_Author(s)_>
+<_Date created_>				2022-05-30 </_Date created_>
+-------------------------------------------------------------------------
+<_Country_>						Thailand (THA) </_Country_>
+<_Survey Title_>				Labor Force Survey 2021 Q4 </_Survey Title_>
+<_Survey Year_>					2021 </_Survey Year_>
+<_Study ID_>					N.A. </_Study ID_>
+<_Data collection from_>		October 2021 </_Data collection from_>
+<_Data collection to_>			December 2021 </_Data collection to_>
+<_Source of dataset_> 			NSO </_Source of dataset_>
+<_Sample size (HH)_> 			73,422 </_Sample size (HH)_>
+<_Sample size (IND)_> 			217,471 </_Sample size (IND)_>
+
+<_Sampling method_> 			
+A stratified two-stage sampling was adopted to the survey: Bangkok Metroplois and the 76 provinces constituted the strata. Each stratum (excluding Bangkok Metropolis) was divided into two parts according to the type of local administration, namely municipal areas and non-municipal areas. The primary and secondary sampling units were enumeration areas (EAs) for municipal areas and non-municipal areas and private households and persons in the collective households respectively.
+
+At the first stage, the EAs based on the 2010 census frame was updated from other sample surveys and selected separately and independently in each stratum by using probability proportional to zero, giving the total number of households.
+
+At the second stage, private households and persons in the collective households were our ultimate sampling units. A new listing of private households was made for every sampled EAs to serve as the sampling frome. In each sampled EAs, a systematic sample of private households were selected with the following sample size: Municipal areas : 16 sample households per EAs and Non-municipal areas : 12 sample households per EAs.
+
+ </_Sampling method_>
+ 
+<_Geographic coverage_> 		National </_Geographic coverage_>
+<_Currency_> 					Thailand Baht </_Currency_>
+-----------------------------------------------------------------------
+<_ICLS Version_>				Not stated </_ICLS Version_>
+<_ISCED Version_>				ISCED 2011 </_ISCED Version_>
+<_ISCO Version_>				ISCO 2008 </_ISCO Version_>
+<_OCCUP National_>				Based on ISCO 2008 </_OCCUP National_>
+<_ISIC Version_>				ISIC version 3 </_ISIC Version_>
+<_INDUS National_>				TSIC 2009 </_INDUS National_>
+-----------------------------------------------------------------------
+<_Version Control_>
+* Date: [2022-05-30] - Prepared initial code
+* Date: [2022-08-31] - Correct industrycat10 - ISIC conversion
+</_Version Control_>
+-------------------------------------------------------------------------*/
+
+
+/*%%=============================================================================================
+	1: Setting up of program environment, dataset
+==============================================================================================%%*/
+
+*----------1.1: Initial commands------------------------------*
+
+clear
+set more off
+set mem 800m
+
+*----------1.2: Set directories------------------------------*
+
+global path_in "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q4\THA_2021_LFS-Q4_v01_M\Data\Stata"
+
+global path_output "Z:\GLD-Harmonization\510859_AS\THA\THA_2021_LFS-Q4\THA_2021_LFS-Q4_v01_M_v02_A_GLD\Data\Harmonized"
+
+*----------1.3: Database assembly------------------------------*
+
+* All steps necessary to merge datasets (if several) to have all elements needed to produce
+* harmonized output in a single file
+
+	use "$path_in\lfs644.dta", clear
+/*%%=============================================================================================
+	2: Survey & ID
+==============================================================================================%%*/
+
+{
+
+*<_countrycode_>
+	gen str4 countrycode = "THA"
+	label var countrycode "Country code"
+*</_countrycode_>
+
+
+*<_survname_>
+	gen survname = "LFS"
+	label var survname "Survey acronym"
+*</_survname_>
+
+
+*<_survey_>
+	gen survey = "LFS"
+	label var survey "Survey type"
+*</_survey_>
+
+
+*<_icls_v_>
+	gen icls_v = "ICLS-13"
+	label var icls_v "ICLS version underlying questionnaire questions"
+*</_icls_v_>
+
+
+
+*<_isced_version_>
+	gen isced_version = "isced_2011"
+	label var isced_version "Version of ISCED used for educat_isced"
+*</_isced_version_>
+
+
+*<_isco_version_>
+	gen isco_version = "isco_2008"
+	label var isco_version "Version of ISCO used"
+*</_isco_version_>
+
+
+*<_isic_version_>
+	gen isic_version = "isic_3"
+	label var isic_version "Version of ISIC used"
+*</_isic_version_>
+
+
+*<_year_>
+	gen int year = 2021
+	label var year "Year of survey"
+*</_year_>
+
+
+*<_vermast_>
+	gen vermast = "V01"
+	label var vermast "Version of master data"
+*</_vermast_>
+
+
+*<_veralt_>
+	gen veralt = "V02"
+	label var veralt "Version of the alt/harmonized data"
+*</_veralt_>
+
+
+*<_harmonization_>
+	gen harmonization = "GLD"
+	label var harmonization "Type of harmonization"
+*</_harmonization_>
+
+
+*<_int_year_>
+	gen int_year= 2021
+	label var int_year "Year of the interview"
+*</_int_year_>
+
+
+*<_int_month_>
+	gen  int_month = MONTH
+	label de lblint_month 1 "January" 2 "February" 3 "March" 4 "April" 5 "May" 6 "June" 7 "July" 8 "August" 9 "September" 10 "October" 11 "November" 12 "December"
+	label value int_month lblint_month
+	label var int_month "Month of the interview"
+*</_int_month_>
+
+
+*<_hhid_>
+/* <_hhid_note>
+	The variable should be a string made up of the elements to define it, that is psu code, ssu, ...
+	Each element should always be as long as needed for the longest element. That is, if there are
+	60 psu coded 1 through 60, codes should be 01, 02, ..., 60. If there are 160 it should be 001,
+	002, ..., 160.
+	
+	In this survey, the HHID can be determined based on the following information:
+	
+	- REG (Region)
+	- CWT (Province)
+	- AREA (Urban/Rural)
+	- PSU_NO (Primary sampling unit)
+	- EA_SET (Area of enumeration)
+	- SAMSET (Sample set)
+	- HH_NO  (Household No)
+	
+</_hhid_note> */
+
+	* First, convert to string
+	
+	foreach var of varlist REG CWT AREA PSU_NO EA_SET HH_NO NO {
+	    tostring `var', gen(`var'_str)
+		
+	}
+	
+	* Make sure elements are consistent in lenght
+	replace PSU_NO_str = "0" + PSU_NO_str if length(PSU_NO_str)==3
+	replace NO_str =  "0" + NO_str if length(NO_str)==1
+
+	egen hhid = concat(REG_str CWT_str AREA_str PSU_NO_str EA_SET_str SAMSET HH_NO_str)
+	label var hhid "Household ID"
+*</_hhid_>
+
+
+*<_pid_>
+
+	drop if missing(NO)
+	
+	egen pid = concat(hhid NO_str)
+	label var pid "Individual ID"
+*</_pid_>
+
+
+*<_weight_>
+
+	gen weight = WGT
+	label var weight "Household sampling weight"
+	
+*</_weight_>
+
+
+*<_psu_>
+	egen psu = concat(REG_str CWT_str AREA_str PSU_NO_str)
+	label var psu "Primary sampling units"
+*</_psu_>
+
+
+*<_ssu_>
+	gen ssu = hhid
+	label var ssu "Secondary sampling units"
+*</_ssu_>
+
+
+*<_strata_>
+	gen strata = CWT_str
+	label var strata "Strata"
+*</_strata_>
+
+
+*<_wave_>
+	gen wave = "Q4"
+	label var wave "Survey wave"
+*</_wave_>
+
+}
+
+/*%%=============================================================================================
+	3: Geography
+==============================================================================================%%*/
+
+{
+
+*<_urban_>
+	gen byte urban = AREA
+	recode urban (2=0)
+	label var urban "Location is urban"
+	la de lblurban 1 "Urban" 0 "Rural"
+	label values urban lblurban
+*</_urban_>
+
+
+*<_subnatid1_>
+/* <_subnatid1>
+	Labels are to be defined as # - Name like 1 "1 - Alaska" 2 "2 - Arkansas".
+	
+	
+</_subnatid1> */
+	gen byte subnatid1 = REG
+	
+	label define region 1 "Bangkok" 2 "Central" 3 "North" 4 "Northeast" 5 "South"
+
+	label de lblsubnatid1 1 "1 - Bangkok" 2 "2 - Central" 3 "3 - North" 4 "4 - Northeast" 5 "5 - South"
+	label values subnatid1 lblsubnatid1
+	label var subnatid1 "Subnational ID at First Administrative Level"
+*</_subnatid1_>
+
+
+*<_subnatid2_>
+	gen byte subnatid2 = CWT
+	label de lblsubnatid2 10 "10 - Bangkok Metropolis" 11 "11 - Samut Prakan" ///
+		12 "12 - Nonthaburi"	13 "13 - Pathum Thani" 14 "14 - Phra Nakhon Si Ayutthaya"  ///
+		15 "15 - Ang Thong" 16 "16 - Lop Buri" 17 "17 - Sing Buri" 18 "18 - Chai Nat" ///
+		19 "19 - Saraburi" 20 "20 - Chon Buri"	21 "21 - Rayong"	22 "22 - Chanthaburi" /// 
+		23 "23 - Trat" 24 "24 - Chachoengsao" 25 "25 - Prachin Buri" ///
+		26 "26 - Nakhon Nayok" 27 "27 - Sa Kaeo" 30 "30 - Nakhon Ratchasima" ///
+		31 "31 - Buri Ram" 32 "32 - Surin" 33 "33 - Si Sa Ket" 34 "34 - Ubon Ratchathani" ///
+		35 "35 - Yasothon" 36 "36 - Chaiyaphum" 37 "37 - Am Nat Charoen" ///
+		38 "38 - Bueng Kan" 39 "39 - Nong Bua Lam Phu" 40 "40 - Khon Kaen" ///
+		41 "41 - Udon Thani" 42 "42 - Loei" 43 "43 - Nong Khai" 44 "44 - Maha Sarakham" ///
+		45 "45 - Roi Et" 46 "46 - Kalasin" 47 "47 - Sakon Nakhon"	48 "48 - Nakhon Phanom"  ///
+		49 "49 - Mukdahan" 50 "50 - Chiang Mai"	51 "51 - Lamphun" 52 "52 - Lampang" 53 "53 - Uttaradit"  ///
+		54 "54 - Phrae"	55 "55 - Nan" 56 "56 - Phayao" 57 "57 - Chiang Rai" 58 "58 - Mae Hong Son" ///
+		60 "60 - Nakhon Sawan" 61 "61 - Uthai Thani"  62 "62 - Kamphaeng Phet" 63 "63 - Tak" 64 "64 - Sukhothai" /// 
+		65 "65 - Phitsanulok"	66 "66 - Phichit" 67 "67 - Phetchabun" 70 "70 - Ratchaburi" ///
+		71 "71 - Kanchanaburi" 72 "72 - Suphan Buri" 73 "73 - Nakhon Pathom" ///
+		74 "74 - Samut Sakhon" 75 "75 - Samut Songkhram" 76 "76 - Phetchaburi"	///
+		77 "77 - Prachuap Khiri Khan" 80 "80 - Nakhon Si Thammarat" 81 "81 - Krabi" ///
+		82 "82 - Phangnga" 83 "83 - Phuket" 84 "84 - Surat Thani" ///
+		85 "85 - Ranong" 86 "86 - Chumphon" 90 "90 - Songkhla" 91 "91 - Satun" 92 "92 - Trang" ///
+		93 "93 - Phatthalung" 94 "94 - Pattani" 95 "95 - Yala" 96 "96 - Narathiwat"
+		
+		
+	label values subnatid2 lblsubnatid2
+	label var subnatid2 "Subnational ID at Second Administrative Level"
+*</_subnatid2_>
+
+
+*<_subnatid3_>
+	gen byte subnatid3 = .
+	label de lblsubnatid3 1 "1 - Name"
+	label values subnatid3 lblsubnatid3
+	label var subnatid3 "Subnational ID at Third Administrative Level"
+*</_subnatid3_>
+
+
+*<_subnatidsurvey_>
+
+/*<_subnatidsurvey_note_>
+
+Have yet to determine the level at which the data is representative
+
+*<_subnatidsurvey_note>*/
+
+	gen subnatidsurvey = "subnatid1"
+	label var subnatidsurvey "Administrative level at which survey is representative"
+	
+*</_subnatidsurvey_>
+
+
+*<_subnatid1_prev_>
+/* <_subnatid1_prev_note>
+	subnatid1_prev is coded as missing unless the classification used for subnatid1 has changed since the previous survey.
+	
+</_subnatid1_prev_note> */
+
+	gen subnatid1_prev = subnatid1
+	recode subnatid1_prev (3 = 1) (4 = 2) (5 = 3) (2 = 4) (1 = 5)
+	label de lblsubnatid1_prev 1 "1 - North" 2 "2 - Northeast" 3 "3 - South" 4 "4 - Central" 5 "5 - Bangkok Metropolis"
+	label values subnatid1_prev lblsubnatid1_prev
+
+	label var subnatid1_prev "Classification used for subnatid1 from previous survey"
+*</_subnatid1_prev_>
+
+
+*<_subnatid2_prev_>
+
+	merge m:1 subnatid2 using "$path_in\changwad_subnatid2_prev.dta", keep(master match)
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+	
+	label de lblsubnatid2_prev  101 "1 - Mae Hong Son" 102 "2 - Chiang Mai"	103 "3 - Phayao" ///
+	104 "4 - Chiang Rai" 105 "5 - Nan" 106 "6 - Lamphun" 107 "7 - Lampang" 108 "8 - Phrae" 109 "9 - Tak" ///
+	110 "10 - Sukhothai" 111 "11 - Uttaradit" 112 "12 - Kamphaeng Phet" 113 "13 - Phichit" 114 "14 - Uthai Thani" ///
+	115 "15 - Nakhon Sawan" 116 "16 - Phitsanulok" 117 "17 - Phetchabun" ///
+	201 "1 - Loei"	202 "2 - Udon Thani" 203 "3 - Nong Khai" 204 "4 - Sakon Nakhon" ///
+	205 "5 - Nakhon Phanom" 206 "6 - Kalasin" 207 "7 - Roi Et" 208 "8 - Maha Sarakham"  ///
+	209 "9 - Khon Daen" 210 "10 - Chaiyaphum" 211 "11 - Nakhon Ratchasima" 212 "12 - Buri Ram" ///
+	213 "13 - Surin" 214 "14 - Si Sa Ket" 215 "15 - Ubon Ratchathani" 216 "16 - Yasothon" ///
+	217 "17 - Mukdahan" 274 "74 - Nong Bua Lam Phu" 275 "75 - Am Nat Charoen" 301 "1 - Chumphon" 302 "2 - Ranong" 303 "3 - Surat Thani" ///
+	304 "4 - Phangnga" 305 "5 - Phuket" 306 "6 - Krabi" 307 "7 - Nakhon Si Thammarat" ///
+	308 "8 - Phatthalung" 309 "9 - Songkhla" 310 "10 - Trang" 311 "11 - Satun" ///
+	312 "12 - Pattani" 313 "13 - Yala" 314 "14 - Narathiwat" 401 "1 - Kanchanaburi" ///
+	402 "2 - Suphan Buri" 403 "3 - Ratchaburi" 404 "4 - Prachuap Khiri Khan" ///
+	405 "5 - Phetchaburi" 406 "6 - Nakhon Pathom" 407 "7 - Samut Songkhram"	/// 
+	408 "8 - Samut Sakhon" 409 "9 - Saraburi" 410 "10 - Lop Buri" ///
+	411 "11 - Phranakhon Si Ayutthaya" 412 "12 - Ang Thong" 413 "13 - Sing Buri" ///
+	414 "14 - Chai Nat" 415 "15 - Trat" 416 "16 - Chanthaburi" 417 "17 - Rayong" 418 "18 - Chon Buri" ///
+	419 "19 - Prachin Buri" 420 "20 - Nakhon Nayok" 421 "21 - Chachoengsao" ///
+	422 "22 - Nonthaburi" 423 "23 - Pathum Thani" 424 "24 - Sumut Prakan" 476 "76 - Sa Kaeo" ///
+	501 "1 - Bangkok Metropolis"
+
+
+	label values subnatid2_prev lblsubnatid2_prev
+	label var subnatid2_prev "Classification used for subnatid2 from previous survey"
+
+	sdecode subnatid1, replace
+	sdecode subnatid1_prev, replace
+	sdecode subnatid2, replace
+	sdecode subnatid2_prev, replace
+
+*</_subnatid2_prev_>
+
+*<_subnatid3_prev_>
+	gen subnatid3_prev = .
+	label var subnatid3_prev "Classification used for subnatid3 from previous survey"
+*</_subnatid3_prev_>
+
+
+/*<_gaul_adm_code_notes>
+
+Based on this reference (https://data.humdata.org/dataset/cod-ab-tha):
+
+level 0 = country
+level 1 = province
+level 2 = district
+level 3 = subdistrict/tambon
+
+* But for the available datasets, the district (amphoe) and tambon are NA
+
+Hence, leave adm2 and adm3 missing
+
+</_gaul_adm_code_notes>*/
+
+*<_gaul_adm1_code_>
+	gen gaul_adm1_code = subnatid2
+	label var gaul_adm1_code "Global Administrative Unit Layers (GAUL) Admin 1 code"
+*</_gaul_adm1_code_>
+
+
+*<_gaul_adm2_code_>
+	gen gaul_adm2_code = .
+	label var gaul_adm2_code "Global Administrative Unit Layers (GAUL) Admin 2 code"
+*</_gaul_adm2_code_>
+
+
+*<_gaul_adm3_code_>
+	gen gaul_adm3_code = .
+	label var gaul_adm3_code "Global Administrative Unit Layers (GAUL) Admin 3 code"
+*</_gaul_adm3_code_>
+
+}
+
+
+
+/*%%=============================================================================================
+	4: Demography
+==============================================================================================%%*/
+
+{
+
+*<_hsize_>
+	gen hsize = MEMBERS
+	
+	* First check if MEMBERS has the same if we were to recreate HH size
+	bys hhid: gen totfam_size = _N
+	assert totfam_size == MEMBERS
+	
+	label var hsize "Household size"
+*</_hsize_>
+
+
+*<_age_>
+	gen age = AGE
+	label var age "Individual age"
+*</_age_>
+
+
+*<_male_>
+	gen male = SEX
+	recode male (2=0)
+	label var male "Sex - Ind is male"
+	la de lblmale 1 "Male" 0 "Female"
+	label values male lblmale
+*</_male_>
+
+
+*<_relationharm_>
+
+	* First check if there are instances where there are no or more than 1 HH head
+	gen head = RELATION==1
+	bys hhid: egen tot_head = sum(head)
+	
+	count if tot_head!=1
+	
+	assert RELATION == 0 if tot_head!=1
+	* Based on the questionnaire: relation = 0 correspond to "member of group of people workers/ monks/ others"
+	
+	gen relationharm = RELATION
+	recode relationharm (3 4 5 6 = 3) (7 8 10 11 12 13 14 = 5) (9 = 4) (15 = 6) (0 = . )
+	label var relationharm "Relationship to the head of household - Harmonized"
+	la de lblrelationharm  1 "Head of household" 2 "Spouse" 3 "Children" 4 "Parents" 5 "Other relatives" 6 "Other and non-relatives"
+	label values relationharm  lblrelationharm
+*</_relationharm_>
+
+
+*<_relationcs_>
+	gen relationcs = .
+	label var relationcs "Relationship to the head of household - Country original"
+*</_relationcs_>
+
+
+*<_marital_>
+	gen byte marital = MARITAL
+	recode marital (2 = 1) (1 = 2) (3 = 5) (5 = 4) (6 = .)
+	label var marital "Marital status"
+	la de lblmarital 1 "Married" 2 "Never Married" 3 "Living together" 4 "Divorced/Separated" 5 "Widowed"
+	label values marital lblmarital
+*</_marital_>
+
+
+*<_eye_dsablty_>
+	gen eye_dsablty = .
+	label var eye_dsablty "Disability related to eyesight"
+*</_eye_dsablty_>
+
+
+*<_hear_dsablty_>
+	gen hear_dsablty = .
+	label var eye_dsablty "Disability related to hearing"
+*</_hear_dsablty_>
+
+
+*<_walk_dsablty_>
+	gen walk_dsablty = .
+	label var eye_dsablty "Disability related to walking or climbing stairs"
+*</_walk_dsablty_>
+
+
+*<_conc_dsord_>
+	gen conc_dsord = .
+	label var eye_dsablty "Disability related to concentration or remembering"
+*</_conc_dsord_>
+
+
+*<_slfcre_dsablty_>
+	gen slfcre_dsablty  = .
+	label var eye_dsablty "Disability related to selfcare"
+*</_slfcre_dsablty_>
+
+
+*<_comm_dsablty_>
+	gen comm_dsablty = .
+	label var eye_dsablty "Disability related to communicating"
+*</_comm_dsablty_>
+
+}
+
+
+/*%%=============================================================================================
+	5: Migration
+==============================================================================================%%*/
+
+
+{
+
+*<_migrated_mod_age_>
+	gen migrated_mod_age = .
+	label var migrated_mod_age "Migration module application age"
+*</_migrated_mod_age_>
+
+
+*<_migrated_ref_time_>
+	gen migrated_ref_time = .
+	label var migrated_ref_time "Reference time applied to migration questions (in years)"
+*</_migrated_ref_time_>
+
+
+*<_migrated_binary_>
+	gen migrated_binary = .
+	label de lblmigrated_binary 0 "No" 1 "Yes"
+	label values migrated_binary lblmigrated_binary
+	label var migrated_binary "Individual has migrated"
+*</_migrated_binary_>
+
+
+*<_migrated_years_>
+	gen migrated_years = .
+	label var migrated_years "Years since latest migration"
+*</_migrated_years_>
+
+
+*<_migrated_from_urban_>
+	gen migrated_from_urban = .
+	label de lblmigrated_from_urban 0 "Rural" 1 "Urban"
+	label values migrated_from_urban lblmigrated_from_urban
+	label var migrated_from_urban "Migrated from area"
+*</_migrated_from_urban_>
+
+
+*<_migrated_from_cat_>
+	gen migrated_from_cat = .
+	label de lblmigrated_from_cat 1 "From same admin3 area" 2 "From same admin2 area" 3 "From same admin1 area" 4 "From other admin1 area" 5 "From other country"
+	label values migrated_from_cat lblmigrated_from_cat
+	label var migrated_from_cat "Category of migration area"
+*</_migrated_from_cat_>
+
+
+*<_migrated_from_code_>
+	gen migrated_from_code = .
+	*label de lblmigrated_from_code
+	*label values migrated_from_code lblmigrated_from_code
+	label var migrated_from_code "Code of migration area as subnatid level of migrated_from_cat"
+*</_migrated_from_code_>
+
+
+*<_migrated_from_country_>
+	gen migrated_from_country = .
+	label var migrated_from_country "Code of migration country (ISO 3 Letter Code)"
+*</_migrated_from_country_>
+
+
+*<_migrated_reason_>
+	gen migrated_reason = .
+	label de lblmigrated_reason 1 "Family reasons" 2 "Educational reasons" 3 "Employment" 4 "Forced (political reasons, natural disaster, …)" 5 "Other reasons"
+	label values migrated_reason lblmigrated_reason
+	label var migrated_reason "Reason for migrating"
+*</_migrated_reason_>
+
+
+}
+
+
+/*%%=============================================================================================
+	6: Education
+==============================================================================================%%*/
+
+
+{
+
+*<_ed_mod_age_>
+
+/* <_ed_mod_age_note>
+Education module is only asked to those 15 years and older.
+
+</_ed_mod_age_note> */
+
+gen byte ed_mod_age = 15
+label var ed_mod_age "Education module application age"
+
+*</_ed_mod_age_>
+
+
+*<_school_>
+	gen byte school= (GRADE_A != 1) & age>=ed_mod_age
+	label var school "Attending school"
+	la de lblschool 0 "No" 1 "Yes"
+	label values school  lblschool
+*</_school_>
+
+
+*<_literacy_>
+	gen byte literacy = .
+	label var literacy "Individual can read & write"
+	la de lblliteracy 0 "No" 1 "Yes"
+	label values literacy lblliteracy
+*</_literacy_>
+
+
+*<_educy_>
+	gen byte educy =.
+	label var educy "Years of education"
+*</_educy_>
+
+
+*<_educat7_>
+	gen byte educat7 = RE_ED
+	recode educat7 (5 6 7  = 5) (8 9 10  = 6) (11 12 13 14 15 = 7)  (16 17 = .)
+
+	label var educat7 "Level of education 1"
+	la de lbleducat7 1 "No education" 2 "Primary incomplete" 3 "Primary complete" 4 "Secondary incomplete" 5 "Secondary complete" 6 "Higher than secondary but not university" 7 "University incomplete or complete"
+	label values educat7 lbleducat7
+*</_educat7_>
+
+
+*<_educat5_>
+	gen byte educat5 = educat7
+	recode educat5 4=3 5=4 6 7=5
+	label var educat5 "Level of education 2"
+	la de lbleducat5 1 "No education" 2 "Primary incomplete"  3 "Primary complete but secondary incomplete" 4 "Secondary complete" 5 "Some tertiary/post-secondary"
+	label values educat5 lbleducat5
+*</_educat5_>
+
+
+*<_educat4_>
+	gen byte educat4 = educat7
+	recode educat4 (2 3 4 = 2) (5=3) (6 7=4)
+	label var educat4 "Level of education 3"
+	la de lbleducat4 1 "No education" 2 "Primary" 3 "Secondary" 4 "Post-secondary"
+	label values educat4 lbleducat4
+*</_educat4_>
+
+
+*<_educat_orig_>
+	gen educat_orig = .
+	label var educat_orig "Original survey education code"
+*</_educat_orig_>
+
+
+*<_educat_isced_>
+	gen educat_isced = ""
+	replace educat_isced = "020" if RE_ED == 2
+	replace educat_isced = "100" if RE_ED == 3
+	replace educat_isced = "244" if RE_ED == 4
+	replace educat_isced = "344" if inrange(RE_ED, 5, 7)
+	replace educat_isced = "354" if RE_ED == 8
+	replace educat_isced = "550" if RE_ED == 9
+	replace educat_isced = "540" if RE_ED == 10
+	replace educat_isced = "660" if inrange(RE_ED, 11, 13)
+	replace educat_isced = "760" if RE_ED == 14
+	replace educat_isced = "860" if RE_ED == 15
+	
+	label var educat_isced "ISCED standardised level of education"
+*</_educat_isced_>
+
+
+*----------6.1: Education cleanup------------------------------*
+
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+local ed_var "school literacy educy educat7 educat5 educat4 educat_orig educat_isced"
+
+foreach v of local ed_var {
+	cap confirm numeric variable `v'
+	if _rc == 0 { // is indeed numeric
+		replace `v'=. if ( age < ed_mod_age & !missing(age) )
+	}
+	else { // is not
+		replace `v'= "" if ( age < ed_mod_age & !missing(age) )
+	}
+}
+
+
+*</_% Correction min age_>
+
+
+}
+
+
+
+/*%%=============================================================================================
+	7: Training
+==============================================================================================%%*/
+
+
+{
+
+*<_vocational_>
+	gen vocational = .
+	label de lblvocational 0 "No" 1 "Yes"
+	label var vocational "Ever received vocational training"
+*</_vocational_>
+
+*<_vocational_type_>
+	gen vocational_type = .
+	label de lblvocational_type 1 "Inside Enterprise" 2 "External"
+	label values vocational_type lblvocational_type
+	label var vocational_type "Type of vocational training"
+*</_vocational_type_>
+
+*<_vocational_length_l_>
+	gen vocational_length_l = .
+	label var vocational_length_l "Length of training in months, lower limit"
+*</_vocational_length_l_>
+
+*<_vocational_length_u_>
+	gen vocational_length_u = .
+	label var vocational_length_u "Length of training in months, upper limit"
+*</_vocational_length_u_>
+
+*<_vocational_field_>
+	gen vocational_field = .
+	label var vocational_field "Field of training"
+*</_vocational_field_>
+
+*<_vocational_financed_>
+	gen vocational_financed = .
+	label de lblvocational_financed 1 "Employer" 2 "Government" 3 "Mixed Employer/Government" 4 "Own funds" 5 "Other"
+	label var vocational_financed "How training was financed"
+*</_vocational_financed_>
+
+}
+
+/*%%=============================================================================================
+	8: Labour
+==============================================================================================%%*/
+
+
+*<_minlaborage_>
+	gen byte minlaborage = 15
+	label var minlaborage "Labor module application age"
+*</_minlaborage_>
+
+
+*----------8.1: 7 day reference overall------------------------------*
+
+{
+
+*<_lstatus_>
+	gen byte lstatus = .
+	replace lstatus = . if age < minlaborage
+	replace lstatus = 1 if WK_7DAY == 1 | RETURN == 1 | RECEIVE == 1
+	replace lstatus = 2 if SEEKING == 1 | (SEEKING == 2 & AVAILABLE == 1)
+	replace lstatus = 3 if (SEEKING == 3 & AVAILABLE == 2) | (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	
+	label var lstatus "Labor status"
+	la de lbllstatus 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus lbllstatus
+*</_lstatus_>
+
+
+*<_potential_lf_>
+	gen byte potential_lf = .
+	replace potential_lf = 0 if lstatus == 3
+	replace potential_lf = 1 if (SEEKING == 3 & AVAILABLE == 1) | (SEEKING == 2 & AVAILABLE == 2)
+	replace potential_lf = . if age < minlaborage & age != .	
+	label var potential_lf "Potential labour force status"
+	la de lblpotential_lf 0 "No" 1 "Yes"
+	label values potential_lf lblpotential_lf
+*</_potential_lf_>
+
+
+*<_underemployment_>
+	gen byte underemployment = .
+	replace underemployment = . if age < minlaborage & age != .
+	replace underemployment = . if lstatus != 1
+	replace underemployment = 1 if lstatus == 1 & MORE_WK == 1
+	replace underemployment = 0 if lstatus == 1 & MORE_WK == 2
+	
+	label var underemployment "Underemployment status"
+	la de lblunderemployment 0 "No" 1 "Yes"
+	label values underemployment lblunderemployment
+*</_underemployment_>
+
+
+*<_nlfreason_>
+	gen byte nlfreason=.
+	replace nlfreason = 1 if RE_UNAVAIL == 2
+	replace nlfreason = 2 if RE_UNAVAIL == 1
+	replace nlfreason = 3 if RE_UNAVAIL == 7
+	replace nlfreason = 4 if RE_UNAVAIL == 5
+	replace nlfreason = 5 if RE_UNAVAIL == 3 | RE_UNAVAIL == 6 | RE_UNAVAIL == 8
+	label var nlfreason "Reason not in the labor force"
+	la de lblnlfreason 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disabled" 5 "Other"
+	label values nlfreason lblnlfreason
+*</_nlfreason_>
+
+
+*<_unempldur_l_>
+	gen byte unempldur_l= 0 if DR_UNEM == 1
+	replace unempldur_l = 1 if DR_UNEM == 2
+	replace unempldur_l = 3 if DR_UNEM == 3
+	replace unempldur_l = 6 if DR_UNEM == 4
+	replace unempldur_l = 9 if DR_UNEM == 5
+	replace unempldur_l = 11.9 if DR_UNEM == 6
+	replace unempldur_l = . if DR_UNEM == 9 | lstatus!=2 
+	label var unempldur_l "Unemployment duration (months) lower bracket"
+*</_unempldur_l_>
+
+
+*<_unempldur_u_>
+	gen byte unempldur_u= 1 if DR_UNEM == 1
+	replace unempldur_u = 2.9 if DR_UNEM == 2
+	replace unempldur_u = 5.9 if DR_UNEM == 3
+	replace unempldur_u = 8.9 if DR_UNEM == 4
+	replace unempldur_u = 11.9 if DR_UNEM == 5
+	replace unempldur_u = . if DR_UNEM == 6
+	replace unempldur_u = . if DR_UNEM == 9 | lstatus!=2 	
+	label var unempldur_u "Unemployment duration (months) upper bracket"
+*</_unempldur_u_>
+}
+
+
+
+*----------8.2: 7 day reference main job------------------------------*
+
+
+{
+*<_empstat_>
+	gen byte empstat= .
+	replace empstat = 1 if STATUS == 4 | STATUS == 5 | STATUS == 6
+	replace empstat = 2 if STATUS == 3
+	replace empstat = 3 if STATUS == 1
+	replace empstat = 4 if STATUS == 2
+	replace empstat = 5 if STATUS == 7 | STATUS == 8
+	
+	replace empstat =. if lstatus!=1
+	
+	label var empstat "Employment status during past week primary job 7 day recall"
+	la de lblempstat 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat lblempstat
+*</_empstat_>
+
+
+
+*<_ocusec_>
+	gen byte ocusec = .
+	replace ocusec = 1 if STATUS == 4
+	replace ocusec = 2 if STATUS == 1 | STATUS == 2 | STATUS == 3 | STATUS == 6 | STATUS == 7 | STATUS == 8
+	replace ocusec = 3 if STATUS == 5
+	label var ocusec "Sector of activity primary job 7 day recall"
+	la de lblocusec 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec lblocusec
+*</_ocusec_>
+
+
+*<_industry_orig_>
+
+	gen industry_orig = INDUS
+	tostring industry_orig, replace
+	replace industry_orig = "0" + industry_orig if length(industry_orig) == 4
+	replace industry_orig = "" if industry_orig == "." | industry_orig == "99999"
+	label var industry_orig "Original survey industry code, main job 7 day recall"
+*</_industry_orig_>
+
+
+*<_industrycat_isic_>
+
+	gen TSIC = industry_orig
+	drop _merge
+	merge m:1 TSIC using "$path_in\TSIC_to_ISIC_v3.dta", keep(master match)
+	gen industrycat_isic = ISIC_v3
+
+	* Correct the typos in the conversion table
+	* This is based on the TSIC 2009 main report from http://statstd.nso.go.th/classification/download.aspx
+
+	replace industrycat_isic = "2927" if industrycat_isic == "2729"
+	replace industrycat_isic = "9309" if industrycat_isic == "9306"
+	
+	label var industrycat_isic "ISIC code of primary job 7 day recall"
+*</_industrycat_isic_>
+
+
+*<_industrycat10_>
+	gen isic_1d = substr(industrycat_isic, 1, 1)
+	gen isic_2d = substr(industrycat_isic, 1, 2)
+	
+	destring isic_1d, replace
+	destring isic_2d, replace
+	
+	gen byte industrycat10 = .
+	replace industrycat10 = 1 if isic_1d == 0
+	replace industrycat10 = 2 if inrange(isic_2d, 10, 14)
+	replace industrycat10 = 3 if inrange(isic_2d, 15, 37)
+	replace industrycat10 = 4 if inrange(isic_2d, 40, 41)
+	replace industrycat10 = 5 if isic_2d == 45
+	replace industrycat10 = 6 if isic_1d == 5
+	replace industrycat10 = 7 if inrange(isic_2d, 60, 64)
+	replace industrycat10 = 8 if inrange(isic_2d, 65, 74)
+	replace industrycat10 = 9 if isic_2d == 75
+	replace industrycat10 = 10 if inrange(isic_2d, 80, 99)
+	
+	label var industrycat10 "1 digit industry classification, primary job 7 day recall"
+	la de lblindustrycat10 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10 lblindustrycat10
+*</_industrycat10_>
+
+
+*<_industrycat4_>
+	gen byte industrycat4 = industrycat10
+	recode industrycat4 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4 "Broad Economic Activities classification, primary job 7 day recall"
+	la de lblindustrycat4 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4 lblindustrycat4
+*</_industrycat4_>
+
+
+*<_occup_orig_>
+	tostring OCCUP, gen(OCCUP_STR)
+	gen occup_orig = OCCUP_STR
+	label var occup_orig "Original occupation record primary job 7 day recall"
+*</_occup_orig_>
+
+
+*<_occup_isco_>
+	* This is based on OCCUP 08
+	gen occup_isco = OCCUP_STR
+	replace occup_isco = "" if OCCUP_STR == "9970"
+	label var occup_isco "ISCO code of primary job 7 day recall"
+*</_occup_isco_>
+
+
+*<_occup_skill_>
+	gen occup_1d = substr(OCCUP_STR, 1, 1)
+	destring occup_1d, replace
+	gen occup_skill = 1 if occup_1d == 9
+	replace occup_skill = 2 if inrange(occup_1d, 4, 8)
+	replace occup_skill = 3 if inrange(occup_1d, 1, 3)
+	
+	la de lblskill 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill lblskill
+	label var occup_skill "Skill based on ISCO standard primary job 7 day recall"
+*</_occup_skill_>
+
+
+*<_occup_>
+	gen byte occup = occup_1d
+	label var occup "1 digit occupational classification, primary job 7 day recall"
+	la de lbloccup 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup lbloccup
+*</_occup_>
+
+
+
+
+*<_wage_no_compen_>
+	gen double wage_no_compen = AMOUNT
+	replace wage_no_compen = . if AMOUNT == 99999
+
+	label var wage_no_compen "Last wage payment primary job 7 day recall"
+*</_wage_no_compen_>
+
+
+*<_unitwage_>
+	gen byte unitwage = .
+	replace unitwage = 1 if WAGE_TYPE == 2
+	replace unitwage = 2 if WAGE_TYPE == 3
+	replace unitwage = 5 if WAGE_TYPE == 4
+	replace unitwage = 6 if WAGE_TYPE == 5
+	replace unitwage = 9 if WAGE_TYPE == 1
+	replace unitwage = . if WAGE_TYPE == 6
+	replace unitwage = . if lstatus!=1 
+	replace unitwage = . if missing(wage_no_compen)
+	label var unitwage "Last wages' time unit primary job 7 day recall"
+	la de lblunitwage 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage lblunitwage
+*</_unitwage_>
+
+
+
+
+*<_whours_>
+	gen whours = MAIN_HR
+	replace whours = . if MAIN_HR == 0
+	label var whours "Hours of work in last week primary job 7 day recall"
+*</_whours_>
+
+*<_wmonths_>
+	gen wmonths = .
+	label var wmonths "Months of work in past 12 months primary job 7 day recall"
+*</_wmonths_>
+
+
+*<_wage_total_>
+/* <_wage_total_note>
+	Use gross wages when available and net wages only when gross wages are not available.
+	This is done to make it easy to compare earnings in formal and informal sectors.
+</_wage_total_note> */
+	gen wage_total = .
+	label var wage_total "Annualized total wage primary job 7 day recall"
+*</_wage_total_>
+
+
+*<_contract_>
+	gen byte contract = .
+	label var contract "Employment has contract primary job 7 day recall"
+	la de lblcontract 0 "Without contract" 1 "With contract"
+	label values contract lblcontract
+*</_contract_>
+
+
+*<_healthins_>
+	gen byte healthins = .
+	label var healthins "Employment has health insurance primary job 7 day recall"
+	la de lblhealthins 0 "Without health insurance" 1 "With health insurance"
+	label values healthins lblhealthins
+*</_healthins_>
+
+
+*<_socialsec_>
+	gen byte socialsec = .
+	label var socialsec "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec 1 "With social security" 0 "Without social secturity"
+	label values socialsec lblsocialsec
+*</_socialsec_>
+
+
+*<_union_>
+	gen byte union = .
+	label var union "Union membership at primary job 7 day recall"
+	la de lblunion 0 "Not union member" 1 "Union member"
+	label values union lblunion
+*</_union_>
+
+
+
+*<_firmsize_l_>
+	ren SIZE_ SIZE
+	gen byte firmsize_l = .
+	replace firmsize_l = 1 if SIZE == 1
+	replace firmsize_l = 5 if SIZE == 2
+	replace firmsize_l = 10 if SIZE == 3
+	replace firmsize_l = 20 if SIZE == 4
+	replace firmsize_l = 50 if SIZE == 5
+	replace firmsize_l = 100 if SIZE == 6
+	replace firmsize_l = 200 if SIZE == 7
+	replace firmsize_l = . if SIZE == 9
+
+	label var firmsize_l "Firm size (lower bracket) primary job 7 day recall"
+*</_firmsize_l_>
+
+
+*<_firmsize_u_>
+	gen byte firmsize_u = .
+	replace firmsize_u = 4 if SIZE == 1
+	replace firmsize_u = 9 if SIZE == 2
+	replace firmsize_u = 19 if SIZE == 3
+	replace firmsize_u = 49 if SIZE == 4
+	replace firmsize_u = 99 if SIZE == 5
+	replace firmsize_u = 199 if SIZE == 6
+	replace firmsize_u = . if SIZE == 7
+	replace firmsize_u = . if SIZE == 9	
+	
+	label var firmsize_u "Firm size (upper bracket) primary job 7 day recall"
+*</_firmsize_u_>
+
+}
+
+
+*----------8.3: 7 day reference secondary job------------------------------*
+* Since labels are the same as main job, values are labelled using main job labels
+
+
+{
+*<_empstat_2_>
+	gen byte empstat_2 = .
+	label var empstat_2 "Employment status during past week secondary job 7 day recall"
+	label values empstat_2 lblempstat
+*</_empstat_2_>
+
+
+*<_ocusec_2_>
+	gen byte ocusec_2 = .
+	label var ocusec_2 "Sector of activity secondary job 7 day recall"
+	label values ocusec_2 lblocusec
+*</_ocusec_2_>
+
+
+*<_industry_orig_2_>
+	gen industry_orig_2 = .
+	label var industry_orig_2 "Original survey industry code, secondary job 7 day recall"
+*</_industry_orig_2_>
+
+
+*<_industrycat_isic_2_>
+	gen industrycat_isic_2 = .
+	label var industrycat_isic_2 "ISIC code of secondary job 7 day recall"
+*</_industrycat_isic_2_>
+
+
+*<_industrycat10_2_>
+	gen byte industrycat10_2 = .
+	label var industrycat10_2 "1 digit industry classification, secondary job 7 day recall"
+	label values industrycat10_2 lblindustrycat10
+*</_industrycat10_2_>
+
+
+*<_industrycat4_2_>
+	gen byte industrycat4_2 = industrycat10_2
+	recode industrycat4_2 (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2 "Broad Economic Activities classification, secondary job 7 day recall"
+	label values industrycat4_2 lblindustrycat4
+*</_industrycat4_2_>
+
+
+*<_occup_orig_2_>
+	gen occup_orig_2 = .
+	label var occup_orig_2 "Original occupation record secondary job 7 day recall"
+*</_occup_orig_2_>
+
+
+*<_occup_isco_2_>
+	gen occup_isco_2 = ""
+	label var occup_isco_2 "ISCO code of secondary job 7 day recall"
+*</_occup_isco_2_>
+
+
+*<_occup_skill_2_>
+	gen occup_skill_2 = .
+	la de lblskill2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2 lblskill2
+	label var occup_skill_2 "Skill based on ISCO standard secondary job 7 day recall"
+*</_occup_skill_2_>
+
+
+*<_occup_2_>
+	gen byte occup_2 = .
+	label var occup_2 "1 digit occupational classification secondary job 7 day recall"
+	label values occup_2 lbloccup
+*</_occup_2_>
+
+
+*<_wage_no_compen_2_>
+	gen double wage_no_compen_2 = .
+	label var wage_no_compen_2 "Last wage payment secondary job 7 day recall"
+*</_wage_no_compen_2_>
+
+
+*<_unitwage_2_>
+	gen byte unitwage_2 = .
+	label var unitwage_2 "Last wages' time unit secondary job 7 day recall"
+	label values unitwage_2 lblunitwage
+*</_unitwage_2_>
+
+
+*<_whours_2_>
+	gen whours_2 = .
+	label var whours_2 "Hours of work in last week secondary job 7 day recall"
+*</_whours_2_>
+
+
+*<_wmonths_2_>
+	gen wmonths_2 = .
+	label var wmonths_2 "Months of work in past 12 months secondary job 7 day recall"
+*</_wmonths_2_>
+
+
+*<_wage_total_2_>
+	gen wage_total_2 = .
+	label var wage_total_2 "Annualized total wage secondary job 7 day recall"
+*</_wage_total_2_>
+
+
+*<_firmsize_l_2_>
+	gen byte firmsize_l_2 = .
+	label var firmsize_l_2 "Firm size (lower bracket) secondary job 7 day recall"
+*</_firmsize_l_2_>
+
+
+*<_firmsize_u_2_>
+	gen byte firmsize_u_2 = .
+	label var firmsize_u_2 "Firm size (upper bracket) secondary job 7 day recall"
+*</_firmsize_u_2_>
+
+}
+
+*----------8.4: 7 day reference additional jobs------------------------------*
+
+*<_t_hours_others_>
+	gen t_hours_others = .
+	label var t_hours_others "Annualized hours worked in all but primary and secondary jobs 7 day recall"
+*</_t_hours_others_>
+
+
+*<_t_wage_nocompen_others_>
+	gen t_wage_nocompen_others = .
+	label var t_wage_nocompen_others "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_others_>
+
+
+*<_t_wage_others_>
+	gen t_wage_others = .
+	label var t_wage_others "Annualized wage in all but primary and secondary jobs (12-mon ref period)"
+*</_t_wage_others_>
+
+
+*----------8.5: 7 day reference total summary------------------------------*
+
+
+*<_t_hours_total_>
+	gen t_hours_total = TOTAL_HR
+	replace t_hours_total = . if TOTAL_HR == 0 | (TOTAL_HR>140 & !missing(TOTAL_HR))
+	replace t_hours_total = t_hours_total * 52
+	
+	label var t_hours_total "Annualized hours worked in all jobs 7 day recall"
+*</_t_hours_total_>
+
+
+*<_t_wage_nocompen_total_>
+	gen t_wage_nocompen_total = .
+	label var t_wage_nocompen_total "Annualized wage in all jobs excl. bonuses, etc. 7 day recall"
+*</_t_wage_nocompen_total_>
+
+
+*<_t_wage_total_>
+	gen t_wage_total = .
+	label var t_wage_total "Annualized total wage for all jobs 7 day recall"
+*</_t_wage_total_>
+
+
+*----------8.6: 12 month reference overall------------------------------*
+
+{
+
+*<_lstatus_year_>
+	gen byte lstatus_year = .
+	replace lstatus_year=. if age < minlaborage & age != .
+	label var lstatus_year "Labor status during last year"
+	la de lbllstatus_year 1 "Employed" 2 "Unemployed" 3 "Non-LF"
+	label values lstatus_year lbllstatus_year
+*</_lstatus_year_>
+
+*<_potential_lf_year_>
+	gen byte potential_lf_year = .
+	replace potential_lf_year=. if age < minlaborage & age != .
+	replace potential_lf_year = . if lstatus_year != 3
+	label var potential_lf_year "Potential labour force status"
+	la de lblpotential_lf_year 0 "No" 1 "Yes"
+	label values potential_lf_year lblpotential_lf_year
+*</_potential_lf_year_>
+
+
+*<_underemployment_year_>
+	gen byte underemployment_year = .
+	replace underemployment_year = . if age < minlaborage & age != .
+	replace underemployment_year = . if lstatus_year == 1
+	label var underemployment_year "Underemployment status"
+	la de lblunderemployment_year 0 "No" 1 "Yes"
+	label values underemployment_year lblunderemployment_year
+*</_underemployment_year_>
+
+
+*<_nlfreason_year_>
+	gen byte nlfreason_year=.
+	label var nlfreason_year "Reason not in the labor force"
+	la de lblnlfreason_year 1 "Student" 2 "Housekeeper" 3 "Retired" 4 "Disable" 5 "Other"
+	label values nlfreason_year lblnlfreason_year
+*</_nlfreason_year_>
+
+
+*<_unempldur_l_year_>
+	gen byte unempldur_l_year=.
+	label var unempldur_l_year "Unemployment duration (months) lower bracket"
+*</_unempldur_l_year_>
+
+
+*<_unempldur_u_year_>
+	gen byte unempldur_u_year=.
+	label var unempldur_u_year "Unemployment duration (months) upper bracket"
+*</_unempldur_u_year_>
+
+}
+
+*----------8.7: 12 month reference main job------------------------------*
+
+{
+
+*<_empstat_year_>
+	gen byte empstat_year = .
+	label var empstat_year "Employment status during past week primary job 12 month recall"
+	la de lblempstat_year 1 "Paid employee" 2 "Non-paid employee" 3 "Employer" 4 "Self-employed" 5 "Other, workers not classifiable by status"
+	label values empstat_year lblempstat_year
+*</_empstat_year_>
+
+*<_ocusec_year_>
+	gen byte ocusec_year = .
+	label var ocusec_year "Sector of activity primary job 12 month recall"
+	la de lblocusec_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_year lblocusec_year
+*</_ocusec_year_>
+
+*<_industry_orig_year_>
+	gen industry_orig_year = .
+	label var industry_orig_year "Original industry record main job 12 month recall"
+*</_industry_orig_year_>
+
+
+*<_industrycat_isic_year_>
+	gen industrycat_isic_year = .
+	label var industrycat_isic_year "ISIC code of primary job 12 month recall"
+*</_industrycat_isic_year_>
+
+*<_industrycat10_year_>
+	gen byte industrycat10_year = .
+	label var industrycat10_year "1 digit industry classification, primary job 12 month recall"
+	la de lblindustrycat10_year 1 "Agriculture" 2 "Mining" 3 "Manufacturing" 4 "Public utilities" 5 "Construction"  6 "Commerce" 7 "Transport and Comnunications" 8 "Financial and Business Services" 9 "Public Administration" 10 "Other Services, Unspecified"
+	label values industrycat10_year lblindustrycat10_year
+*</_industrycat10_year_>
+
+
+*<_industrycat4_year_>
+	gen byte industrycat4_year=industrycat10_year
+	recode industrycat4_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_year "Broad Economic Activities classification, primary job 12 month recall"
+	la de lblindustrycat4_year 1 "Agriculture" 2 "Industry" 3 "Services" 4 "Other"
+	label values industrycat4_year lblindustrycat4_year
+*</_industrycat4_year_>
+
+
+*<_occup_orig_year_>
+	gen occup_orig_year = .
+	label var occup_orig_year "Original occupation record primary job 12 month recall"
+*</_occup_orig_year_>
+
+
+*<_occup_isco_year_>
+	gen occup_isco_year = ""
+	label var occup_isco_year "ISCO code of primary job 12 month recall"
+*</_occup_isco_year_>
+
+
+*<_occup_skill_year_>
+	gen occup_skill_year = .
+	la de lblskillyear 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_year lblskillyear
+	label var occup_skill_year "Skill based on ISCO standard primary job 12 month recall"
+*</_occup_skill_year_>
+
+
+*<_occup_year_>
+	gen byte occup_year = .
+	label var occup_year "1 digit occupational classification, primary job 12 month recall"
+	la de lbloccup_year 1 "Managers" 2 "Professionals" 3 "Technicians" 4 "Clerks" 5 "Service and market sales workers" 6 "Skilled agricultural" 7 "Craft workers" 8 "Machine operators" 9 "Elementary occupations" 10 "Armed forces"  99 "Others"
+	label values occup_year lbloccup_year
+*</_occup_year_>
+
+
+*<_wage_no_compen_year_> --- this var has the same name as other and when quoted in the keep and order codes is repeated.
+	gen double wage_no_compen_year = .
+	label var wage_no_compen_year "Last wage payment primary job 12 month recall"
+*</_wage_no_compen_year_>
+
+
+*<_unitwage_year_>
+	gen byte unitwage_year = .
+	label var unitwage_year "Last wages' time unit primary job 12 month recall"
+	la de lblunitwage_year 1 "Daily" 2 "Weekly" 3 "Every two weeks" 4 "Bimonthly"  5 "Monthly" 6 "Trimester" 7 "Biannual" 8 "Annually" 9 "Hourly" 10 "Other"
+	label values unitwage_year lblunitwage_year
+*</_unitwage_year_>
+
+
+*<_whours_year_>
+	gen whours_year = .
+	label var whours_year "Hours of work in last week primary job 12 month recall"
+*</_whours_year_>
+
+
+*<_wmonths_year_>
+	gen wmonths_year = .
+	label var wmonths_year "Months of work in past 12 months primary job 12 month recall"
+*</_wmonths_year_>
+
+
+*<_wage_total_year_>
+	gen wage_total_year = .
+	label var wage_total_year "Annualized total wage primary job 12 month recall"
+*</_wage_total_year_>
+
+
+*<_contract_year_>
+	gen byte contract_year = .
+	label var contract_year "Employment has contract primary job 12 month recall"
+	la de lblcontract_year 0 "Without contract" 1 "With contract"
+	label values contract_year lblcontract_year
+*</_contract_year_>
+
+
+*<_healthins_year_>
+	gen byte healthins_year = .
+	label var healthins_year "Employment has health insurance primary job 12 month recall"
+	la de lblhealthins_year 0 "Without health insurance" 1 "With health insurance"
+	label values healthins_year lblhealthins_year
+*</_healthins_year_>
+
+
+*<_socialsec_year_>
+	gen byte socialsec_year = .
+	label var socialsec_year "Employment has social security insurance primary job 7 day recall"
+	la de lblsocialsec_year 1 "With social security" 0 "Without social secturity"
+	label values socialsec_year lblsocialsec_year
+*</_socialsec_year_>
+
+
+*<_union_year_>
+	gen byte union_year = .
+	label var union_year "Union membership at primary job 12 month recall"
+	la de lblunion_year 0 "Not union member" 1 "Union member"
+	label values union_year lblunion_year
+*</_union_year_>
+
+
+*<_firmsize_l_year_>
+	gen byte firmsize_l_year = .
+	label var firmsize_l_year "Firm size (lower bracket) primary job 12 month recall"
+*</_firmsize_l_year_>
+
+
+*<_firmsize_u_year_>
+	gen byte firmsize_u_year = .
+	label var firmsize_u_year "Firm size (upper bracket) primary job 12 month recall"
+*</_firmsize_u_year_>
+
+}
+
+
+*----------8.8: 12 month reference secondary job------------------------------*
+
+{
+
+*<_empstat_2_year_>
+	gen byte empstat_2_year = .
+	label var empstat_2_year "Employment status during past week secondary job 12 month recall"
+	label values empstat_2_year lblempstat_year
+*</_empstat_2_year_>
+
+
+*<_ocusec_2_year_>
+	gen byte ocusec_2_year = .
+	label var ocusec_2_year "Sector of activity secondary job 12 month recall"
+	la de lblocusec_2_year 1 "Public Sector, Central Government, Army" 2 "Private, NGO" 3 "State owned" 4 "Public or State-owned, but cannot distinguish"
+	label values ocusec_2_year lblocusec_2_year
+*</_ocusec_2_year_>
+
+
+
+*<_industry_orig_2_year_>
+	gen industry_orig_2_year = .
+	label var industry_orig_2_year "Original survey industry code, secondary job 12 month recall"
+*</_industry_orig_2_year_>
+
+
+
+*<_industrycat_isic_2_year_>
+	gen industrycat_isic_2_year = .
+	label var industrycat_isic_2_year "ISIC code of secondary job 12 month recall"
+*</_industrycat_isic_2_year_>
+
+
+*<_industrycat10_2_year_>
+	gen byte industrycat10_2_year = .
+	label var industrycat10_2_year "1 digit industry classification, secondary job 12 month recall"
+	label values industrycat10_2_year lblindustrycat10_year
+*</_industrycat10_2_year_>
+
+
+*<_industrycat4_2_year_>
+	gen byte industrycat4_2_year=industrycat10_2_year
+	recode industrycat4_2_year (1=1)(2 3 4 5 =2)(6 7 8 9=3)(10=4)
+	label var industrycat4_2_year "Broad Economic Activities classification, secondary job 12 month recall"
+	label values industrycat4_2_year lblindustrycat4_year
+*</_industrycat4_2_year_>
+
+
+*<_occup_orig_2_year_>
+	gen occup_orig_2_year = .
+	label var occup_orig_2_year "Original occupation record secondary job 12 month recall"
+*</_occup_orig_2_year_>
+
+
+*<_occup_isco_2_year_>
+	gen occup_isco_2_year = ""
+	label var occup_isco_2_year "ISCO code of secondary job 12 month recall"
+*</_occup_isco_2_year_>
+
+
+*<_occup_skill_2_year_>
+	gen occup_skill_2_year = .
+	la de lblskilly2 1 "Low skill" 2 "Medium skill" 3 "High skill"
+	label values occup_skill_2_year lblskilly2
+	label var occup_skill_2_year "Skill based on ISCO standard secondary job 12 month recall"
+*</_occup_skill_2_year_>
+
+
+*<_occup_2_year_>
+	gen byte occup_2_year = .
+	label var occup_2_year "1 digit occupational classification, secondary job 12 month recall"
+	label values occup_2_year lbloccup_year
+*</_occup_2_year_>
+
+
+*<_wage_no_compen_2_year_>
+	gen double wage_no_compen_2_year = .
+	label var wage_no_compen_2_year "Last wage payment secondary job 12 month recall"
+*</_wage_no_compen_2_year_>
+
+
+*<_unitwage_2_year_>
+	gen byte unitwage_2_year = .
+	label var unitwage_2_year "Last wages' time unit secondary job 12 month recall"
+	label values unitwage_2_year lblunitwage_year
+*</_unitwage_2_year_>
+
+
+*<_whours_2_year_>
+	gen whours_2_year = .
+	label var whours_2_year "Hours of work in last week secondary job 12 month recall"
+*</_whours_2_year_>
+
+
+*<_wmonths_2_year_>
+	gen wmonths_2_year = .
+	label var wmonths_2_year "Months of work in past 12 months secondary job 12 month recall"
+*</_wmonths_2_year_>
+
+
+*<_wage_total_2_year_>
+	gen wage_total_2_year = .
+	label var wage_total_2_year "Annualized total wage secondary job 12 month recall"
+*</_wage_total_2_year_>
+
+*<_firmsize_l_2_year_>
+	gen byte firmsize_l_2_year = .
+	label var firmsize_l_2_year "Firm size (lower bracket) secondary job 12 month recall"
+*</_firmsize_l_2_year_>
+
+
+*<_firmsize_u_2_year_>
+	gen byte firmsize_u_2_year = .
+	label var firmsize_u_2_year "Firm size (upper bracket) secondary job 12 month recall"
+*</_firmsize_u_2_year_>
+
+}
+
+
+*----------8.9: 12 month reference additional jobs------------------------------*
+
+
+*<_t_hours_others_year_>
+	gen t_hours_others_year = .
+	label var t_hours_others_year "Annualized hours worked in all but primary and secondary jobs 12 month recall"
+*</_t_hours_others_year_>
+
+*<_t_wage_nocompen_others_year_>
+	gen t_wage_nocompen_others_year = .
+	label var t_wage_nocompen_others_year "Annualized wage in all but 1st & 2nd jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_others_year_>
+
+*<_t_wage_others_year_>
+	gen t_wage_others_year = .
+	label var t_wage_others_year "Annualized wage in all but primary and secondary jobs 12 month recall"
+*</_t_wage_others_year_>
+
+
+*----------8.10: 12 month total summary------------------------------*
+
+
+*<_t_hours_total_year_>
+	gen t_hours_total_year = .
+	label var t_hours_total_year "Annualized hours worked in all jobs 12 month month recall"
+*</_t_hours_total_year_>
+
+
+*<_t_wage_nocompen_total_year_>
+	gen t_wage_nocompen_total_year = .
+	label var t_wage_nocompen_total_year "Annualized wage in all jobs excl. bonuses, etc. 12 month recall"
+*</_t_wage_nocompen_total_year_>
+
+
+*<_t_wage_total_year_>
+	gen t_wage_total_year = .
+	label var t_wage_total_year "Annualized total wage for all jobs 12 month recall"
+*</_t_wage_total_year_>
+
+
+*----------8.11: Overall across reference periods------------------------------*
+
+
+*<_njobs_>
+	gen njobs = .
+	label var njobs "Total number of jobs"
+*</_njobs_>
+
+
+*<_t_hours_annual_>
+	gen t_hours_annual = .
+	label var t_hours_annual "Total hours worked in all jobs in the previous 12 months"
+*</_t_hours_annual_>
+
+
+*<_linc_nc_>
+	gen linc_nc = .
+	label var linc_nc "Total annual wage income in all jobs, excl. bonuses, etc."
+*</_linc_nc_>
+
+
+*<_laborincome_>
+	gen laborincome = t_wage_total_year
+	label var laborincome "Total annual individual labor income in all jobs, incl. bonuses, etc."
+*</_laborincome_>
+
+
+*----------8.13: Labour cleanup------------------------------*
+
+
+* Set missing values for unemployed with responses on occupation and industry questions
+foreach var of varlist ocusec empstat industry_orig industrycat_isic industrycat10  industrycat4 occup_orig occup occup_isco wage_no_compen unitwage firmsize_l firmsize_u {
+	cap confirm numeric variable `var'
+	
+	if _rc==0 {
+		replace `var' = . if lstatus !=1
+	}
+	else {
+		replace `var' = "" if lstatus !=1
+	}
+}
+
+{
+*<_% Correction min age_>
+
+** Drop info for cases under the age for which questions to be asked (do not need a variable for this)
+	local lab_var "minlaborage lstatus nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome"
+
+	foreach v of local lab_var {
+		cap confirm numeric variable `v'
+		if _rc == 0 { // is indeed numeric
+			replace `v'=. if ( age < minlaborage & !missing(age) )
+		}
+		else { // is not
+			replace `v'= "" if ( age < minlaborage & !missing(age) )
+		}
+
+	}
+
+*</_% Correction min age_>
+}
+
+
+/*%%=============================================================================================
+	9: Final steps
+==============================================================================================%%*/
+
+quietly{
+
+*<_% KEEP VARIABLES - ALL_>
+
+	keep countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% KEEP VARIABLES - ALL_>
+
+*<_% ORDER VARIABLES_>
+
+	order countrycode survname survey icls_v isced_version isco_version isic_version year vermast veralt harmonization int_year int_month hhid pid weight psu strata wave urban subnatid1 subnatid2 subnatid3 subnatidsurvey subnatid1_prev subnatid2_prev subnatid3_prev gaul_adm1_code gaul_adm2_code gaul_adm3_code hsize age male relationharm relationcs marital eye_dsablty hear_dsablty walk_dsablty conc_dsord slfcre_dsablty comm_dsablty migrated_mod_age migrated_ref_time migrated_binary migrated_years migrated_from_urban migrated_from_cat migrated_from_code migrated_from_country migrated_reason ed_mod_age school literacy educy educat7 educat5 educat4 educat_orig educat_isced vocational vocational_type vocational_length_l vocational_length_u vocational_field vocational_financed minlaborage lstatus potential_lf underemployment nlfreason unempldur_l unempldur_u empstat ocusec industry_orig industrycat_isic industrycat10 industrycat4 occup_orig occup_isco occup_skill occup wage_no_compen unitwage whours wmonths wage_total contract healthins socialsec union firmsize_l firmsize_u empstat_2 ocusec_2 industry_orig_2 industrycat_isic_2 industrycat10_2 industrycat4_2 occup_orig_2 occup_isco_2 occup_skill_2 occup_2 wage_no_compen_2 unitwage_2 whours_2 wmonths_2 wage_total_2 firmsize_l_2 firmsize_u_2 t_hours_others t_wage_nocompen_others t_wage_others t_hours_total t_wage_nocompen_total t_wage_total lstatus_year potential_lf_year underemployment_year nlfreason_year unempldur_l_year unempldur_u_year empstat_year ocusec_year industry_orig_year industrycat_isic_year industrycat10_year industrycat4_year occup_orig_year occup_isco_year occup_skill_year occup_year wage_no_compen_year unitwage_year whours_year wmonths_year wage_total_year contract_year healthins_year socialsec_year union_year firmsize_l_year firmsize_u_year empstat_2_year ocusec_2_year industry_orig_2_year industrycat_isic_2_year industrycat10_2_year industrycat4_2_year occup_orig_2_year occup_isco_2_year occup_skill_2_year occup_2_year wage_no_compen_2_year unitwage_2_year whours_2_year wmonths_2_year wage_total_2_year firmsize_l_2_year firmsize_u_2_year t_hours_others_year t_wage_nocompen_others_year t_wage_others_year t_hours_total_year t_wage_nocompen_total_year t_wage_total_year njobs t_hours_annual linc_nc laborincome
+
+*</_% ORDER VARIABLES_>
+
+*<_% DROP UNUSED LABELS_>
+
+	* Store all labels in data
+	label dir
+	local all_lab `r(names)'
+
+	* Store all variables with a label, extract value label names
+	local used_lab = ""
+	ds, has(vallabel)
+
+	local labelled_vars `r(varlist)'
+
+	foreach varName of local labelled_vars {
+		local y : value label `varName'
+		local used_lab `"`used_lab' `y'"'
+	}
+
+	* Compare lists, `notused' is list of labels in directory but not used in final variables
+	local notused 		: list all_lab - used_lab 		// local `notused' defines value labs not in remaining vars
+	local notused_len 	: list sizeof notused 			// store size of local
+
+	* drop labels if the length of the notused vector is 1 or greater, otherwise nothing to drop
+	if `notused_len' >= 1 {
+		label drop `notused'
+	}
+	else {
+		di "There are no unused labels to drop. No value labels dropped."
+	}
+
+
+*</_% DROP UNUSED LABELS_>
+
+}
+
+
+*<_% COMPRESS_>
+
+compress
+
+*</_% COMPRESS_>
+
+
+*<_% DELETE MISSING VARIABLES_>
+
+quietly: describe, varlist
+local kept_vars `r(varlist)'
+
+foreach var of local kept_vars {
+   capture assert missing(`var')
+   if !_rc drop `var'
+}
+
+*</_% DELETE MISSING VARIABLES_>
+
+
+*<_% SAVE_>
+
+save "$path_output\THA_2021_LFS-Q4_v01_M_v02_A_GLD_ALL.dta", replace
+
+*</_% SAVE_>


### PR DESCRIPTION
Made changes on the following:
- update industrycat10 for 2000 - 2010
- resolved the issue of missing industrycat10 in 2011 Q2 - Q4
- converted industrycat_isic (based on v1) into four digits by adding two zeroes
- changed subnatid1 and subnatid2 labels into string
- added labels to migrated_from_code (adopting those from subnatid2)
- resolved cases of missing
- updated 2004 Q1 version 3- initially saved with v02 in the filename
- set to missing all responses to industrycat10 when respondent is unemployed or NLF
- filled out educat_orig
- resolved issue missing industrycat10 for a subset of employed individuals in some years